### PR TITLE
Set minHeight for ExpandingTextarea

### DIFF
--- a/doc/reference/atoms/Image.md
+++ b/doc/reference/atoms/Image.md
@@ -30,4 +30,4 @@ src={'https://placeimg.com/nothing'}
 |src **(required)**|string|The URL of the image
 |srcFallback|string|The URL of the fallback image
 |size|enum|The behaviour behavior of image within the container
-|position|enum|The position of image<br>Default: 'left'
+|position|enum|The position of image

--- a/doc/reference/molecules/ExpandingTextarea.md
+++ b/doc/reference/molecules/ExpandingTextarea.md
@@ -3,7 +3,15 @@ This is an auto-generated markdown.
 You can change it in "src/molecules/ExpandingTextarea.jsx" and run build:docs to update this file.
 -->
 # ExpandingTextarea
+The height of the ExpandingTextarea will expand when the user adds a new line.
+It will take at maximum 25% of the current viewport. (max-height: 25vh)
 
+```example
+<ExpandingTextarea>
+  placeholder="Write somthing..."
+  value=""
+/>
+```
 ## Usage
 | Name        | Type           | Description  |
 | ----------- |:--------------:| ------------:|

--- a/src/molecules/Card/CardOverlayEditor.jsx
+++ b/src/molecules/Card/CardOverlayEditor.jsx
@@ -21,7 +21,7 @@ const styles = {
   }),
 }
 
-export default class PostEditor extends React.Component {
+export default class CardOverlayEditor extends React.Component {
   static propTypes = {
     initialText: PropTypes.string,
     confirmText: PropTypes.string.isRequired,

--- a/src/molecules/ExpandingTextarea.jsx
+++ b/src/molecules/ExpandingTextarea.jsx
@@ -17,6 +17,17 @@ const styles = {
   }),
 }
 
+/**
+ * The height of the ExpandingTextarea will expand when the user adds a new line.
+ * It will take at maximum 25% of the current viewport. (max-height: 25vh)
+ *
+ * ```example
+ * <ExpandingTextarea>
+ *   placeholder="Write somthing..."
+ *   value=""
+ * />
+ * ```
+ */
 export default class ExpandingTextarea extends React.Component {
   static propTypes = {
     autoFocus: PropTypes.bool,

--- a/src/molecules/ExpandingTextarea.jsx
+++ b/src/molecules/ExpandingTextarea.jsx
@@ -10,6 +10,7 @@ const styles = {
     fontSize: 13,
     resize: 'none',
     flex: 1,
+    minHeight: 20,
     maxHeight: '25vh',
     width: '100%',
     paddingLeft: 15,


### PR DESCRIPTION
In IE11 the textarea was not visible, this PR fixes it by providing a min-height.

- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


