### PR TITLE
Allow to pass background color for Checkbox and TextInput

### DIFF
--- a/src/molecules/Checkbox.jsx
+++ b/src/molecules/Checkbox.jsx
@@ -37,11 +37,16 @@ const styles = {
  */
 class Checkbox extends React.Component {
   static propTypes = {
+    /** True to make it checked */
     checked: PropTypes.bool,
+    /** Label of Checkbox */
     label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
+    /** Text size of the label */
     labelSize: Text.propTypes.size,
     name: PropTypes.string.isRequired,
     onChange: PropTypes.func,
+    /** Background color of the form item */
+    backgroundColor: PropTypes.string,
   }
 
   state = {
@@ -56,13 +61,21 @@ class Checkbox extends React.Component {
   handleChange = () => this.setState(({ checked }) => ({ checked: !checked }))
 
   render() {
-    const { checked, onChange, label, labelSize, name, ...props } = this.props
+    const {
+      checked,
+      onChange,
+      label,
+      labelSize,
+      name,
+      backgroundColor,
+      ...props
+    } = this.props
     const realChecked = checked || this.state.checked
     const changeHandler = onChange || this.handleChange
     return (
       <Theme>
         {({ theme, colorize }) => (
-          <ListItem backgroundColor={theme.background}>
+          <ListItem backgroundColor={backgroundColor}>
             <View direction="row" alignV="center">
               <Relative {...styles.checkbox(theme.primary, realChecked)}>
                 <Absolute top={1} left={5}>

--- a/src/molecules/Checkbox.jsx
+++ b/src/molecules/Checkbox.jsx
@@ -75,7 +75,7 @@ class Checkbox extends React.Component {
     return (
       <Theme>
         {({ theme, colorize }) => (
-          <ListItem backgroundColor={backgroundColor}>
+          <ListItem backgroundColor={colorize(backgroundColor)}>
             <View direction="row" alignV="center">
               <Relative {...styles.checkbox(theme.primary, realChecked)}>
                 <Absolute top={1} left={5}>

--- a/src/molecules/Checkbox.test.js
+++ b/src/molecules/Checkbox.test.js
@@ -3,7 +3,7 @@ import Checkbox from './Checkbox'
 import { ThemeProvider } from '../'
 
 const THEME = {
-    background: 'darkMarco',
+  background: 'darkMarco',
 }
 const STRING_LABEL = 'I am a nice checkbox!'
 
@@ -29,7 +29,7 @@ describe('Test the checkbox component', () => {
   it('should work with children', () => {
     const wrapper = mount(
       <ThemeProvider theme={THEME}>
-        <Checkbox label={<h1>test</h1>} name="a" />
+        <Checkbox label={<h1>test</h1>} name="a" backgroundColor="darkMarco" />
       </ThemeProvider>
     )
     expect(wrapper).toMatchSnapshot()

--- a/src/molecules/TextInput.jsx
+++ b/src/molecules/TextInput.jsx
@@ -156,11 +156,11 @@ class TextInput extends React.Component {
   handleMessageClick = () => this.setState({ message: null })
 
   render() {
-    const { required, lines, ...props } = this.props
+    const { required, backgroundColor, lines, ...props } = this.props
     return (
       <Theme>
         {({ theme, colorize }) => (
-          <ListItem padded={false}>
+          <ListItem padded={false} backgroundColor={colorize(backgroundColor)}>
             <Relative style={{ width: '100%' }}>
               {this.state.message && (
                 <InputError onClick={this.handleMessageClick}>

--- a/src/molecules/TextInput.jsx
+++ b/src/molecules/TextInput.jsx
@@ -105,6 +105,8 @@ class TextInput extends React.Component {
     minLength: PropTypes.number,
     /** Max number of characters that can be provided */
     maxLength: PropTypes.number,
+    /** Background color of the form item */
+    backgroundColor: PropTypes.string,
   }
 
   state = {

--- a/src/molecules/__snapshots__/Checkbox.test.js.snap
+++ b/src/molecules/__snapshots__/Checkbox.test.js.snap
@@ -14,12 +14,12 @@ exports[`Test the checkbox component should tick it 1`] = `
   border: 3px solid lightGrey;
 }
 
-.css-l8kta8,
-[data-css-l8kta8] {
+.css-1m9hm8a,
+[data-css-1m9hm8a] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
-  background-color: darkMarco;
+  background-color: white;
 }
 
 .css-h7582n,
@@ -84,8 +84,8 @@ exports[`Test the checkbox component should tick it 1`] = `
 }
 
 <div
+  data-css-1m9hm8a=""
   data-css-h7582n=""
-  data-css-l8kta8=""
 >
   <div
     data-css-h7582n=""
@@ -162,12 +162,12 @@ exports[`Test the checkbox component should tick it 2`] = `
   position: relative;
 }
 
-.css-l8kta8,
-[data-css-l8kta8] {
+.css-1m9hm8a,
+[data-css-1m9hm8a] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
-  background-color: darkMarco;
+  background-color: white;
 }
 
 .css-h7582n,
@@ -241,8 +241,8 @@ exports[`Test the checkbox component should tick it 2`] = `
 }
 
 <div
+  data-css-1m9hm8a=""
   data-css-h7582n=""
-  data-css-l8kta8=""
 >
   <div
     data-css-h7582n=""
@@ -327,14 +327,6 @@ exports[`Test the checkbox component should work with children 1`] = `
   border: 3px solid lightGrey;
 }
 
-.css-l8kta8,
-[data-css-l8kta8] {
-  padding: 10px 15px;
-  min-height: 50px;
-  border-bottom: 1px solid #ecf0f1;
-  background-color: darkMarco;
-}
-
 .css-h7582n,
 [data-css-h7582n] {
   box-sizing: border-box;
@@ -394,6 +386,14 @@ exports[`Test the checkbox component should work with children 1`] = `
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #333333;
+}
+
+.css-l8kta8,
+[data-css-l8kta8] {
+  padding: 10px 15px;
+  min-height: 50px;
+  border-bottom: 1px solid #ecf0f1;
+  background-color: darkMarco;
 }
 
 <div


### PR DESCRIPTION
**This changes the background color behaviour introduced in https://github.com/allthings/elements/pull/95**

In #95 the default behavior of Checkbox was changed. It takes the background color from the theme as background color of the ListItem the Checkbox is using. The background color of the theme is also used for the **background the UI elements are placed** on. 

So the change of #95 get's us this default behaviour: 

<img width="308" alt="screen shot 2018-02-05 at 13 03 14" src="https://user-images.githubusercontent.com/224866/35803773-4ee7757c-0a75-11e8-84ed-364fe87f61a1.png">

Only the Checkbox form element now has the default behaviour of having the same color as the background, and this cannot be changed. And changes the behavior of all existing checkboxes. 

I assume this is not what we actually want. My changes allow to pass a _backgroundColor_ as  a prop to the Checkbox and also the TextInput, and they get just passed to the ListItem.

Checklist:

- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


