### PR TITLE
export resource path and loadLanguage

### DIFF
--- a/doc/reference/atoms/View.md
+++ b/doc/reference/atoms/View.md
@@ -14,7 +14,7 @@ For explanation see:
 
 ```example
 <ThemeProvider>
-  <View fill direction="row" alignH="flex-end">
+  <View fill direction="row" alignH="end">
     <Text>Say Hello!</Text>
   </View>
 </ThemeProvider>

--- a/doc/reference/behaviour/CDNIntlProvider.md
+++ b/doc/reference/behaviour/CDNIntlProvider.md
@@ -8,9 +8,9 @@ You can change it in "src/behaviour/CDNIntlProvider.jsx" and run build:docs to u
 | Name        | Type           | Description  |
 | ----------- |:--------------:| ------------:|
 |children|node|
-|locale **(required)**|string|
-|messages|object|
-|onDone|func|<br>Default: _ => _
-|project **(required)**|string|
-|stage|enum|<br>Default: 'production'
-|variation|string|<br>Default: 'default'
+|locale **(required)**|string|Locale you like to get, EN_us, DE_de
+|messages|object|Optionally pass messages. This will prevent initial loading.
+|onDone|func|Called when new languages got loaded<br>Default: _ => _
+|project **(required)**|string|The project ID loading the langauges for
+|stage|enum|Stage, can be production and staging<br>Default: 'production'
+|variation|string|"Default" by default. Can be any allowed variation string.<br>Default: 'default'

--- a/doc/reference/behaviour/CDNIntlProvider.md
+++ b/doc/reference/behaviour/CDNIntlProvider.md
@@ -1,0 +1,16 @@
+<!-- 
+This is an auto-generated markdown. 
+You can change it in "src/behaviour/CDNIntlProvider.jsx" and run build:docs to update this file.
+-->
+# CDNIntlProvider
+
+## Usage
+| Name        | Type           | Description  |
+| ----------- |:--------------:| ------------:|
+|children|node|
+|locale **(required)**|string|
+|messages|object|
+|onDone|func|<br>Default: _ => _
+|project **(required)**|string|
+|stage|enum|<br>Default: 'production'
+|variation|string|<br>Default: 'default'

--- a/doc/reference/molecules/Card/Card.md
+++ b/doc/reference/molecules/Card/Card.md
@@ -8,7 +8,7 @@ Cards can be used to group related content
 ```example
 <Card>
  <CardContent>
-   <Text size="xxl" strong>
+   <Text size="xl" strong>
      Cards
    </Text>
    <Text>

--- a/doc/reference/molecules/Checkbox.md
+++ b/doc/reference/molecules/Checkbox.md
@@ -14,8 +14,9 @@ Checkbox are used to give users a way to select or deselect options.
 ## Usage
 | Name        | Type           | Description  |
 | ----------- |:--------------:| ------------:|
-|onChange|func|
-|checked|bool|<br>Default: false
+|checked|bool|True to make it checked<br>Default: false
+|label **(required)**|union|Label of Checkbox
+|labelSize|custom|Text size of the label<br>Default: 'l'
 |name **(required)**|string|
-|label **(required)**|string|
-|labelSize|custom|<br>Default: 'l'
+|onChange|func|
+|backgroundColor|string|Background color of the form item

--- a/doc/reference/molecules/ExpandingTextarea.md
+++ b/doc/reference/molecules/ExpandingTextarea.md
@@ -7,7 +7,7 @@ The height of the ExpandingTextarea will expand when the user adds a new line.
 It will take at maximum 25% of the current viewport. (max-height: 25vh)
 
 ```example
-<ExpandingTextarea>
+<ExpandingTextarea
   placeholder="Write somthing..."
   value=""
 />

--- a/doc/reference/molecules/Form/Form.md
+++ b/doc/reference/molecules/Form/Form.md
@@ -110,4 +110,4 @@ Also see the <a href="/molecules/TextInput/">TextInput</a> for allowed props.
 | Name        | Type           | Description  |
 | ----------- |:--------------:| ------------:|
 |children|node|
-|onSubmit **(required)**|func|
+|onSubmit **(required)**|func|<br>Default: _ => _

--- a/doc/reference/molecules/Slider.md
+++ b/doc/reference/molecules/Slider.md
@@ -18,5 +18,5 @@ Slider give the user a way to select from a limited range of numbers.
 |min **(required)**|number|Minimum selectable value *
 |max **(required)**|number|Maximum selectable value *
 |step|number|Step interval *<br>Default: 0.1
-|value **(required)**|number|Current value to show *
-|onChange **(required)**|func|Callback when the users changes the value *
+|value|number|Current value to show *
+|onChange|func|Callback when the users changes the value *

--- a/doc/reference/molecules/SquareIconButton.md
+++ b/doc/reference/molecules/SquareIconButton.md
@@ -7,7 +7,7 @@ Button with only an icon. Can be used in toolbars. May also be used
 for back-buttons in the titlebar.
 
 ```example
-<SquareIconButton icon="armchairFilled" color="red" iconColor="white" />
+<SquareIconButton icon="armchair-filled" color="red" iconColor="white" />
 ```
 ## Usage
 | Name        | Type           | Description  |

--- a/doc/reference/molecules/TextInput.md
+++ b/doc/reference/molecules/TextInput.md
@@ -7,7 +7,7 @@ TextInputs are used to allow users to enter information like names, numbers, url
 
 ```example
 <TextInput name="email" type="email" placeholder="Your email" required />
-<TextInput lines={5} placeholder="Your question" maxLength={255} minLength={50} />
+<TextInput name="inquiry" lines={5} placeholder="Your question" maxLength={255} minLength={50} />
 ```
 ## Usage
 | Name        | Type           | Description  |
@@ -22,3 +22,4 @@ TextInputs are used to allow users to enter information like names, numbers, url
 |pattern|string|Regular expression to validate against
 |minLength|number|Min number of characters that must be provided
 |maxLength|number|Max number of characters that can be provided
+|backgroundColor|string|Background color of the form item

--- a/doc/reference/organisms/Hero.md
+++ b/doc/reference/organisms/Hero.md
@@ -8,7 +8,7 @@ Heros are used to give users an introduction and quickly explain features.
 ```example
 <ThemeProvider>
     <Hero text="You are my Hero!" img="https://placeimg.com/500/500/people">
-      <View fill direction="row" alignH="space-between" alignV="space-between">
+      <View fill direction="row" alignH="space-between" alignV="stretch">
         <Button backgroundColor="rgba(0,0,0,0.2)" color="white">Thank you</Button>
       </View>
     </Hero>

--- a/doc/reference/organisms/TitleBar.md
+++ b/doc/reference/organisms/TitleBar.md
@@ -9,12 +9,12 @@ Title bar is used to give user control and information about navigation.
 <ThemeProvider>
   <TitleBar alignH="space-between" color="blueIntense">
     <View direction="row" alignV="center">
-      <SquareIconButton icon="ArmchairFilledIcon" iconColor="white" />
+      <SquareIconButton icon="armchair-filled" iconColor="white" />
       <Text color="white" strong>
         Get Relaxed
       </Text>
     </View>
-    <SquareIconButton icon="SearchFilledIcon" iconColor="white" />
+    <SquareIconButton icon="search-filled" iconColor="white" />
   </TitleBar>
 </ThemeProvider>
 ```

--- a/src/behaviour/CDNIntlProvider.jsx
+++ b/src/behaviour/CDNIntlProvider.jsx
@@ -19,11 +19,17 @@ export const loadLanguage = async (
 class CDNIntlProvider extends React.Component {
   static propTypes = {
     children: PropTypes.node,
+    /* Locale you like to get, EN_us, DE_de */
     locale: PropTypes.string.isRequired,
+    /* Optionally pass messages. This will prevent initial loading. */
     messages: PropTypes.object,
+    /* Called when new languages got loaded */
     onDone: PropTypes.func,
+    /* The project ID loading the langauges for */
     project: PropTypes.string.isRequired,
+    /* Stage, can be production and staging */
     stage: PropTypes.oneOf(['prerelease', 'production', 'staging']),
+    /* "Default" by default. Can be any allowed variation string.  */
     variation: PropTypes.string,
   }
 

--- a/src/behaviour/CDNIntlProvider.jsx
+++ b/src/behaviour/CDNIntlProvider.jsx
@@ -19,17 +19,17 @@ export const loadLanguage = async (
 class CDNIntlProvider extends React.Component {
   static propTypes = {
     children: PropTypes.node,
-    /* Locale you like to get, EN_us, DE_de */
+    /** Locale you like to get, EN_us, DE_de */
     locale: PropTypes.string.isRequired,
-    /* Optionally pass messages. This will prevent initial loading. */
+    /** Optionally pass messages. This will prevent initial loading. */
     messages: PropTypes.object,
-    /* Called when new languages got loaded */
+    /** Called when new languages got loaded */
     onDone: PropTypes.func,
-    /* The project ID loading the langauges for */
+    /** The project ID loading the langauges for */
     project: PropTypes.string.isRequired,
-    /* Stage, can be production and staging */
+    /** Stage, can be production and staging */
     stage: PropTypes.oneOf(['prerelease', 'production', 'staging']),
-    /* "Default" by default. Can be any allowed variation string.  */
+    /** "Default" by default. Can be any allowed variation string.  */
     variation: PropTypes.string,
   }
 

--- a/src/behaviour/CDNIntlProvider.jsx
+++ b/src/behaviour/CDNIntlProvider.jsx
@@ -2,6 +2,20 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { IntlProvider } from 'react-intl'
 
+export const loadLanguage = async (
+  resourcePath,
+  project,
+  variation,
+  locale,
+  stage
+) => {
+  const countryCode = locale.split('_')[0]
+  const translations = await fetch(
+    `${resourcePath}/${project}/${stage}/i18n/${countryCode}/${variation}.json`
+  )
+  return translations.json()
+}
+
 class CDNIntlProvider extends React.Component {
   static propTypes = {
     children: PropTypes.node,
@@ -33,7 +47,7 @@ class CDNIntlProvider extends React.Component {
   }
 
   componentWillMount() {
-    !this.props.messages && this.loadLanguages(this.props)
+    !this.props.messages && this.loadLanguage(this.props)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -48,13 +62,14 @@ class CDNIntlProvider extends React.Component {
   }
 
   loadLanguages = async props => {
-    const { locale, project, stage, variation } = props
-    const countryCode = locale.split('_')[0]
-    const { resourcePath } = this.context
-    const translations = await fetch(
-      `${resourcePath}/${project}/${stage}/i18n/${countryCode}/${variation}.json`
+    const { project, variation, locale, stage } = props
+    const messages = await loadLanguage(
+      this.context.resourcePath,
+      project,
+      variation,
+      locale,
+      stage
     )
-    const messages = await translations.json()
     this.setState({
       loaded: true,
       messages,

--- a/src/behaviour/CDNIntlProvider.jsx
+++ b/src/behaviour/CDNIntlProvider.jsx
@@ -53,7 +53,7 @@ class CDNIntlProvider extends React.Component {
   }
 
   componentWillMount() {
-    !this.props.messages && this.loadLanguage(this.props)
+    !this.props.messages && this.loadLanguages(this.props)
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/behaviour/ResourceProvider.jsx
+++ b/src/behaviour/ResourceProvider.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+export const RESOURCE_PATH = 'https://static.allthings.me'
+
 /**
  * Elements uses a set of static resources like images or icons.
  * In order to benefit from caching across all apps, these resources are provided by a static asset CDN.
@@ -22,7 +24,7 @@ class ResourceProvider extends React.Component {
   }
 
   static defaultProps = {
-    resourcePath: 'https://static.allthings.me',
+    resourcePath: RESOURCE_PATH,
     children: null,
   }
 


### PR DESCRIPTION
Now exporting `loadLanguage` and `RESOURCE_PATH` for easy reuse in synchron server side rendering.

Checklist:

- [x] Test added / Snapshots updated
- [x] Documentation added / updated


