### PR TITLE
Add HorizontalView

### DIFF
--- a/doc/reference/behaviour/HorizontalView.md
+++ b/doc/reference/behaviour/HorizontalView.md
@@ -1,0 +1,50 @@
+<!-- 
+This is an auto-generated markdown. 
+You can change it in "src/behaviour/HorizontalView.jsx" and run build:docs to update this file.
+-->
+# HorizontalView
+HorizontalView is used to Views in a horizontal row, and will do smooth transitions between them.
+The HorizontalView will always show the latest item that get's passed in as a children.
+
+So for this, it will only show the SceondItem.
+```
+<HorizontalView>
+ <FirstItem />
+ <SecondItem />
+</HorizontalView>
+```
+
+To do transitions between the items, you just *pass* in or *remove children*. So if we update the previous example
+to be like this, it will transition from the SecondItem to the FirstItem:
+
+```
+<HorizontalView>
+ <FirstItem />
+</HorizontalView>
+```
+
+## Using with React Router
+The HorizontalView can work perfectly together with React Router. It will allow you
+to have smooth transition from one Route to another.
+
+### Example
+We are building a taco app, because everyone likes tacos. It consists of 3 screens:
+An overview of all available tacos (/tacos), a taco detail page (/tacos/:id) and a list of dips for that are
+a good fit with that taco (/tacos/:id/dips).
+
+If you go to `/tacos` only the first route will be matched, the `TacoList` will render.
+Now you click a link in the `TacosList` it will bring you to `/tacos/8343`. React Router will
+render `TacosList` and `TacosDetail` and HorizontalView do a smooth transition from `TacosList` to
+`TacosDetail`.
+
+```
+<HorizontalView>
+ <Route path="/tacos" component={TacosList}/>
+ <Route path="/tacos/:id" component={TacosDetail}/>
+ <Route path="/tacos/:id/dips" component={TacosDipsView}/>
+</HorizontalView>
+```
+## Usage
+| Name        | Type           | Description  |
+| ----------- |:--------------:| ------------:|
+|children **(required)**|array|

--- a/src/behaviour/HorizontalView.jsx
+++ b/src/behaviour/HorizontalView.jsx
@@ -1,0 +1,127 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import View from '../atoms/View'
+import { css } from 'glamor'
+
+/**
+ * HorizontalView is used to Views in a horizontal row, and will do smooth transitions between them.
+ * The HorizontalView will always show the latest item that get's passed in as a children.
+ *
+ * So for this, it will only show the SceondItem.
+ * ```
+ * <HorizontalView>
+ *  <FirstItem />
+ *  <SecondItem />
+ * </HorizontalView>
+ * ```
+ *
+ * To do transitions between the items, you just *pass* in or *remove children*. So if we update the previous example
+ * to be like this, it will transition from the SecondItem to the FirstItem:
+ *
+ * ```
+ * <HorizontalView>
+ *  <FirstItem />
+ * </HorizontalView>
+ * ```
+ *
+ * ## Using with React Router
+ * The HorizontalView can work perfectly together with React Router. It will allow you
+ * to have smooth transition from one Route to another.
+ *
+ * ### Example
+ * We are building a taco app, because everyone likes tacos. It consists of 3 screens:
+ * An overview of all available tacos (/tacos), a taco detail page (/tacos/:id) and a list of dips for that are
+ * a good fit with that taco (/tacos/:id/dips).
+ *
+ * If you go to `/tacos` only the first route will be matched, the `TacoList` will render.
+ * Now you click a link in the `TacosList` it will bring you to `/tacos/8343`. React Router will
+ * render `TacosList` and `TacosDetail` and HorizontalView do a smooth transition from `TacosList` to
+ * `TacosDetail`.
+ *
+ * ```
+ * <HorizontalView>
+ *  <Route path="/tacos" component={TacosList}/>
+ *  <Route path="/tacos/:id" component={TacosDetail}/>
+ *  <Route path="/tacos/:id/dips" component={TacosDipsView}/>
+ * </HorizontalView>
+ * ```
+ **/
+class HorizontalView extends React.Component {
+  static propTypes = {
+    children: PropTypes.array.isRequired,
+  }
+
+  constructor(props, context) {
+    super(props, context)
+
+    const children = props.children
+    const currentChild = children.length
+
+    this.state = {
+      children,
+      currentChild,
+      nextChildren: null,
+      waitForTransitionEnd: false,
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const oldChildren = this.props.children
+    const nextChildren = nextProps.children
+
+    if (nextChildren.length < oldChildren.length) {
+      this.setState({
+        nextChildren,
+        waitForTransitionEnd: true,
+        currentChild: nextChildren.length,
+      })
+    } else {
+      this.setState({
+        children: nextChildren,
+        currentChild: nextChildren.length,
+      })
+    }
+  }
+
+  handleTransitionEnd = () => {
+    if (this.state.waitForTransitionEnd) {
+      this.setState({
+        children: this.state.nextChildren,
+        nextChildren: null,
+        waitForTransitionEnd: false,
+      })
+    }
+  }
+
+  render() {
+    const { currentChild, children } = this.state
+    const { children: propsChildren, ...props } = this.props
+    const translateX = (currentChild - 1) * -100
+
+    return (
+      <View
+        direction="row"
+        flex="flex"
+        {...css({
+          transform: `translate3d(${translateX}%, 0, 0)`,
+          transition: '.5s',
+        })}
+        onTransitionEnd={this.handleTransitionEnd}
+        {...props}
+      >
+        {children.map((child, i) => (
+          <View
+            key={i}
+            {...css({ width: '100%' })}
+            flex="none"
+            direction="column"
+          >
+            {child}
+          </View>
+        ))}
+      </View>
+    )
+  }
+}
+
+export default HorizontalView

--- a/src/behaviour/HorizontalView.jsx
+++ b/src/behaviour/HorizontalView.jsx
@@ -7,7 +7,7 @@ import { css } from 'glamor'
  * HorizontalView is used to Views in a horizontal row, and will do smooth transitions between them.
  * The HorizontalView will always show the latest item that get's passed in as a children.
  *
- * So for this, it will only show the SceondItem.
+ * So for this, it will only show the SecondItem.
  * ```
  * <HorizontalView>
  *  <FirstItem />
@@ -111,6 +111,7 @@ class HorizontalView extends React.Component {
       >
         {children.map((child, i) => (
           <View
+            // eslint-disable-next-line
             key={i}
             {...css({ width: '100%' })}
             flex="none"

--- a/stories/HorizontalView.jsx
+++ b/stories/HorizontalView.jsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import {
+  ThemeProvider,
+  TitleBar,
+  SquareIconButton,
+  Text,
+  Button,
+  View,
+  CardList,
+  ListItem,
+  ResourceProvider,
+} from '../src'
+import HorizontalView from '../src/behaviour/HorizontalView'
+
+export default class HorizontalViewStory extends React.Component {
+  state = {
+    level: 3,
+  }
+
+  prevLevel = () =>
+    this.setState(state => ({
+      level: state.level - 1,
+    }))
+
+  nextLevel = () =>
+    this.setState(state => ({
+      level: state.level + 1,
+    }))
+
+  render() {
+    return (
+      <ResourceProvider>
+        <ThemeProvider>
+          <View fill direction="column" alignV="stretch">
+            <TitleBar alignH="space-between" color="blueIntense">
+              <View direction="row" alignV="center">
+                <SquareIconButton icon="ArmchairFilledIcon" iconColor="white" />
+                <Text color="white" strong>
+                  Get Relaxed
+                </Text>
+              </View>
+              <SquareIconButton icon="SearchFilledIcon" iconColor="white" />
+            </TitleBar>
+            <View direction="row" flex="flex">
+              <HorizontalView>
+                {Array(this.state.level)
+                  .fill({})
+                  .map((_, i) => (
+                    <CardList key={i} direction="column">
+                      <ListItem>
+                        <Text>{`Test ${i}`}</Text>
+                      </ListItem>
+                    </CardList>
+                  ))}
+              </HorizontalView>
+            </View>
+            <View direction="row" alignH="space-around" style={{ margin: 15 }}>
+              <Button onClick={this.prevLevel} disabled={this.state.level <= 1}>
+                Back
+              </Button>
+              <Button onClick={this.nextLevel} disabled={this.state.level >= 6}>
+                Next
+              </Button>
+            </View>
+          </View>
+        </ThemeProvider>
+      </ResourceProvider>
+    )
+  }
+}

--- a/stories/createViewportDecorator.jsx
+++ b/stories/createViewportDecorator.jsx
@@ -1,0 +1,107 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { css } from 'glamor'
+
+const styles = {
+  wrapper: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    position: 'absolute',
+    width: '100%',
+    minHeight: '100vh',
+    left: 0,
+    top: 0,
+    background: '#efefef',
+    fontSmooth: 'auto',
+    WebkitFontSmoothing: 'antialiased',
+    MozOsxFontSmoothing: 'auto',
+  }),
+
+  mobileView: css({
+    width: 320,
+    height: 568,
+    boxShadow: '0px 0px 6px 0px rgba(0, 0, 0, 0.15)',
+    background: '#f0f2f5',
+    marginTop: 40,
+    overflow: 'auto',
+    position: 'relative',
+  }),
+}
+
+export class Viewport extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+  }
+
+  state = {
+    width: 320,
+    height: 630,
+    padding: false,
+    shiftPressed: false,
+  }
+
+  togglePadding = () => this.setState(({ padding }) => ({ padding: !padding }))
+
+  setWidth = e => {
+    const width = +e.target.value
+    this.setState(() => ({ width }))
+  }
+  setHeight = e => {
+    const height = +e.target.value
+    this.setState(() => ({ height }))
+  }
+
+  setShiftPressed = e => {
+    const { shiftKey } = e
+    if (
+      (!this.state.shiftPressed && shiftKey) ||
+      (this.state.shiftPressed && !shiftKey)
+    ) {
+      this.setState(() => ({ shiftPressed: shiftKey }))
+    }
+  }
+
+  render() {
+    const { width, height } = this.state
+
+    return (
+      <div {...styles.wrapper}>
+        <div {...css({ flexDirection: 'row' })}>
+          <input
+            type="number"
+            style={{ width: 40 }}
+            value={width}
+            step={this.state.shiftPressed ? 10 : 1}
+            onChange={this.setWidth}
+            onKeyDown={this.setShiftPressed}
+            onKeyUp={this.setShiftPressed}
+          />
+          <span>⨉</span>
+          <input
+            type="number"
+            style={{ width: 40 }}
+            value={height}
+            step={this.state.shiftPressed ? 10 : 1}
+            onChange={this.setHeight}
+            onKeyDown={this.setShiftPressed}
+            onKeyUp={this.setShiftPressed}
+          />
+          <label>
+            <input type="checkbox" onClick={this.togglePadding} /> With padding?
+          </label>
+        </div>
+        <div
+          {...css(styles.mobileView, { padding: this.state.padding && 20 })}
+          style={{ width, height }}
+        >
+          {this.props.children}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default function createViewportDecorator() {
+  return story => <Viewport>{story()}</Viewport>
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -10,6 +10,12 @@ import {
   TextInput,
   ThemeProvider,
 } from '../src/'
+import HorizontalView from './HorizontalView'
+import createViewportDecorator from './createViewportDecorator'
+
+storiesOf('Animations', module)
+  .addDecorator(createViewportDecorator())
+  .add('HorizontalView', () => <HorizontalView />)
 
 storiesOf('FloatingButton', module).add('with text', () => (
   <ThemeProvider>


### PR DESCRIPTION
Checklist:

- [x] Test added / Snapshots updated
- [x] Documentation added / updated

# HorizontalView
HorizontalView is used to Views in a horizontal row, and will do smooth transitions between them.
The HorizontalView will always show the latest item that get's passed in as a children.

So for this, it will only show the SceondItem.
```
<HorizontalView>
 <FirstItem />
 <SecondItem />
</HorizontalView>
```

To do transitions between the items, you just *pass* in or *remove children*. So if we update the previous example
to be like this, it will transition from the SecondItem to the FirstItem:

```
<HorizontalView>
 <FirstItem />
</HorizontalView>
```

## Using with React Router
The HorizontalView can work perfectly together with React Router. It will allow you
to have smooth transition from one Route to another.

### Example
We are building a taco app, because everyone likes tacos. It consists of 3 screens:
An overview of all available tacos (/tacos), a taco detail page (/tacos/:id) and a list of dips for that are
a good fit with that taco (/tacos/:id/dips).

If you go to `/tacos` only the first route will be matched, the `TacoList` will render.
Now you click a link in the `TacosList` it will bring you to `/tacos/8343`. React Router will
render `TacosList` and `TacosDetail` and HorizontalView do a smooth transition from `TacosList` to
`TacosDetail`.

```
<HorizontalView>
 <Route path="/tacos" component={TacosList}/>
 <Route path="/tacos/:id" component={TacosDetail}/>
 <Route path="/tacos/:id/dips" component={TacosDipsView}/>
</HorizontalView>
```
## Usage
| Name        | Type           | Description  |
| ----------- |:--------------:| ------------:|
|children **(required)**|array|


