### PR TITLE
Prevent double render of CDNIntlProvider

### DIFF
--- a/src/behaviour/CDNIntlProvider.jsx
+++ b/src/behaviour/CDNIntlProvider.jsx
@@ -44,18 +44,21 @@ class CDNIntlProvider extends React.Component {
     resourcePath: PropTypes.string,
   }
 
-  constructor(props) {
-    super(props)
+  constructor(props, context) {
+    super(props, context)
+    const messages = props.messages
+    this.state = {
+      messages,
+    }
 
-    if (typeof document !== 'undefined') {
+    if (!messages && typeof document !== 'undefined') {
       const container = document.getElementById('__ELEMENTS_INTL__')
-
-      const stateString = container.getAttribute('data-state')
-      this.state = { messages: JSON.parse(stateString) }
-      this.isClient = true
-    } else {
-      this.state = { messages: this.props.messages }
-      this.isClient = false
+      if (container) {
+        const stateString = container.getAttribute('data-state')
+        this.state = { messages: JSON.parse(stateString) }
+      } else {
+        this.loadLanguages(props)
+      }
     }
   }
 
@@ -86,10 +89,9 @@ class CDNIntlProvider extends React.Component {
 
   renderSideEffect = messages => (
     <span
-      suppressHydrationWarning
       id="__ELEMENTS_INTL__"
       style={{ display: 'none' }}
-      data-state={!this.isClient && messages && JSON.stringify(messages)}
+      data-state={messages && JSON.stringify(messages)}
     />
   )
 

--- a/src/behaviour/CDNIntlProvider.jsx
+++ b/src/behaviour/CDNIntlProvider.jsx
@@ -50,7 +50,6 @@ class CDNIntlProvider extends React.Component {
     this.state = {
       messages,
     }
-
     if (!messages && typeof document !== 'undefined') {
       const container = document.getElementById('__ELEMENTS_INTL__')
       if (container) {
@@ -103,7 +102,7 @@ class CDNIntlProvider extends React.Component {
       <IntlProvider locale={countryCode} messages={messages}>
         <Fragment>
           {this.renderSideEffect(messages)}
-          {this.props.children}
+          {messages && this.props.children}
         </Fragment>
       </IntlProvider>
     )

--- a/src/behaviour/CDNIntlProvider.test.jsx
+++ b/src/behaviour/CDNIntlProvider.test.jsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { hydrate } from 'react-dom'
 import renderer from 'react-test-renderer'
 import { FormattedMessage } from 'react-intl'
 import CDNIntlProvider from './CDNIntlProvider'
@@ -103,5 +105,39 @@ describe('Check the CDNIntlProvider component', () => {
     )
     expect(wrapper).toMatchSnapshot()
     expect(wrapper.props().stage).toBe(stage)
+  })
+
+  it('should pick up if hyrdated', ok => {
+    const div = document.createElement('div')
+
+    const dom = renderToString(
+      <ResourceProvider>
+        <CDNIntlProvider
+          messages={{ test: 'Bonjour tout le monde et ala' }}
+          locale="fr_FR"
+          project="app"
+          variation="residential-formal"
+        >
+          <FormattedMessage id="test" defaultMessage="Default" />
+        </CDNIntlProvider>
+      </ResourceProvider>
+    )
+
+    div.innerHTML = dom
+    document.body.appendChild(div)
+
+    hydrate(
+      <ResourceProvider>
+        <CDNIntlProvider
+          locale="fr_FR"
+          project="app"
+          variation="residential-formal"
+        >
+          <FormattedMessage id="test" defaultMessage="Default" />
+        </CDNIntlProvider>
+      </ResourceProvider>,
+      div,
+      () => expect(div.innerHTML).toMatchSnapshot() & ok()
+    )
   })
 })

--- a/src/behaviour/__snapshots__/CDNIntlProvider.test.jsx.snap
+++ b/src/behaviour/__snapshots__/CDNIntlProvider.test.jsx.snap
@@ -34,6 +34,8 @@ Array [
 ]
 `;
 
+exports[`Check the CDNIntlProvider component should pick up if hyrdated 1`] = `"<span id=\\"__ELEMENTS_INTL__\\" style=\\"display:none\\" data-state=\\"{&quot;test&quot;:&quot;Bonjour tout le monde et ala&quot;}\\"></span><span>Bonjour tout le monde et ala</span>"`;
+
 exports[`Check the CDNIntlProvider component should use the correct stage 1`] = `
 <CDNIntlProvider
   locale="fr_FR"

--- a/src/behaviour/__snapshots__/CDNIntlProvider.test.jsx.snap
+++ b/src/behaviour/__snapshots__/CDNIntlProvider.test.jsx.snap
@@ -1,15 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Check the CDNIntlProvider component should fetch the corresponding locales 1`] = `
-<span>
-  Hallo Welt
-</span>
+Array [
+  <span
+    data-state="{\\"test\\":\\"Hallo Welt\\"}"
+    id="__ELEMENTS_INTL__"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  />,
+  <span>
+    Hallo Welt
+  </span>,
+]
 `;
 
 exports[`Check the CDNIntlProvider component should fetch the corresponding locales 2`] = `
-<span>
-  Hello World
-</span>
+Array [
+  <span
+    data-state="{\\"test\\":\\"Hello World\\"}"
+    id="__ELEMENTS_INTL__"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  />,
+  <span>
+    Hello World
+  </span>,
+]
 `;
 
 exports[`Check the CDNIntlProvider component should use the correct stage 1`] = `
@@ -34,7 +56,18 @@ exports[`Check the CDNIntlProvider component should use the correct stage 1`] = 
 `;
 
 exports[`Check the CDNIntlProvider component should use the provided locale and do no fetch 1`] = `
-<span>
-  Bonjour tout le monde
-</span>
+Array [
+  <span
+    data-state="{\\"test\\":\\"Bonjour tout le monde\\"}"
+    id="__ELEMENTS_INTL__"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  />,
+  <span>
+    Bonjour tout le monde
+  </span>,
+]
 `;


### PR DESCRIPTION
This introduces a new HTML element which renders differently on client and server side (with [hydrate](https://reactjs.org/docs/react-dom.html#hydrate) in mind) to rehydrate the messages.
This needs to happen in the constructor because the IntlProvider implementation does not behave well on prop changes (see https://github.com/yahoo/react-intl/issues/1097#issuecomment-363114792)

Discussion in #176 

Checklist:

- [x] Test added / Snapshots updated
- [ ] Documentation added / updated


