### PR TITLE
Input checkmark & autofill fixes

### DIFF
--- a/src/atoms/Input.jsx
+++ b/src/atoms/Input.jsx
@@ -62,6 +62,15 @@ const styles = {
     borderRight: '10px solid transparent',
     borderTop: '10px solid #c1392b',
   }),
+  checkmark: show =>
+    css({
+      position: 'absolute',
+      top: 16,
+      right: 15,
+      pointerEvents: 'none',
+      transition: 'opacity .225s',
+      opacity: show ? 1 : 0,
+    }),
   required: css({
     position: 'absolute',
     right: 10,
@@ -195,6 +204,12 @@ class Input extends React.Component {
     const labelVisible = currentValue.length > 0
     const showLabel = label && currentValue.length > 0
 
+    const isCheckmarkActive =
+      (pattern || props.minLength || props.maxLength || required) &&
+      this.input &&
+      this.input.validity &&
+      this.input.validity.valid
+
     return (
       <Theme>
         {({ theme, colorize }) => (
@@ -236,21 +251,14 @@ class Input extends React.Component {
                 </Text>
               </View>
             )}
-            {pattern &&
-              this.input &&
-              this.input.validity &&
-              this.input.validity.valid && (
-                <View
-                  {...css({
-                    position: 'absolute',
-                    top: 16,
-                    right: 15,
-                    pointerEvents: 'none',
-                  })}
-                >
-                  <Icon name="checkFilled" size="xs" color="lightGrey" />
-                </View>
-              )}
+
+            <View
+              className="checkmark"
+              {...styles.checkmark(isCheckmarkActive)}
+            >
+              <Icon name="check-filled" size="xs" color="lightGrey" />
+            </View>
+
             {props.maxLength && (
               <View {...styles.placeholder}>
                 <Text color="secondaryText" size="s">

--- a/src/atoms/Input.jsx
+++ b/src/atoms/Input.jsx
@@ -17,9 +17,12 @@ const styles = {
       paddingTop: showLabel ? 10 : 0,
       transition: 'padding-top .225s ease-out',
       border: 0,
-      '&:-webkit-autofill ~ div': {
+      '&:-webkit-autofill ~ .label': {
         opacity: '1 !important',
         top: '8px !important',
+      },
+      '&:-webkit-autofill ~ .checkmark': {
+        opacity: '1 !important',
       },
       '&:-webkit-autofill': {
         paddingTop: '10px !important',
@@ -233,6 +236,7 @@ class Input extends React.Component {
             ) : (
               <textarea
                 {...styles.area(theme.secondaryText, lines, showLabel)}
+                required={required}
                 {...props}
                 ref={onInputRef}
                 onChange={this.handleChange}

--- a/src/atoms/Input.jsx
+++ b/src/atoms/Input.jsx
@@ -244,6 +244,7 @@ class Input extends React.Component {
             )}
             {label && (
               <View
+                className="label"
                 {...styles.label}
                 style={{
                   opacity: labelVisible ? 1 : 0,

--- a/src/atoms/__snapshots__/Input.test.jsx.snap
+++ b/src/atoms/__snapshots__/Input.test.jsx.snap
@@ -124,6 +124,7 @@ exports[`Input component should render with all props 1`] = `
     value="string"
   />
   <div
+    className="label"
     data-css-4p3ux5=""
     data-css-lwcmpf=""
     style={

--- a/src/atoms/__snapshots__/Input.test.jsx.snap
+++ b/src/atoms/__snapshots__/Input.test.jsx.snap
@@ -19,8 +19,8 @@ exports[`Input component should render with all props 1`] = `
   right: 15px;
 }
 
-.css-10rv4m6,
-[data-css-10rv4m6] {
+.css-188vfvu,
+[data-css-188vfvu] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -37,17 +37,34 @@ exports[`Input component should render with all props 1`] = `
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-10rv4m6:-webkit-autofill ~ div,
-[data-css-10rv4m6]:-webkit-autofill ~ div {
+.css-188vfvu:-webkit-autofill ~ .label,
+[data-css-188vfvu]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-10rv4m6:-webkit-autofill,
-[data-css-10rv4m6]:-webkit-autofill,
-.css-10rv4m6[data-simulate-webkitautofill],
-[data-css-10rv4m6][data-simulate-webkitautofill] {
+.css-188vfvu:-webkit-autofill ~ .checkmark,
+[data-css-188vfvu]:-webkit-autofill ~ .checkmark {
+  opacity: 1 !important;
+}
+
+.css-188vfvu:-webkit-autofill,
+[data-css-188vfvu]:-webkit-autofill,
+.css-188vfvu[data-simulate-webkitautofill],
+[data-css-188vfvu][data-simulate-webkitautofill] {
   padding-top: 10px !important;
+}
+
+.css-1gnizwt,
+[data-css-1gnizwt] {
+  position: absolute;
+  top: 16px;
+  right: 15px;
+  pointer-events: none;
+  transition: opacity .225s;
+  opacity: 0;
+  -webkit-transition: opacity .225s;
+  -moz-transition: opacity .225s;
 }
 
 .css-13azwyo,
@@ -93,7 +110,7 @@ exports[`Input component should render with all props 1`] = `
 >
   <input
     aria-required={true}
-    data-css-10rv4m6=""
+    data-css-188vfvu=""
     defaultValue="string"
     maxLength={1}
     minLength={1}
@@ -126,6 +143,29 @@ exports[`Input component should render with all props 1`] = `
     </div>
   </div>
   <div
+    className="checkmark"
+    data-css-1gnizwt=""
+    data-css-4p3ux5=""
+  >
+    <div
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
+      data-css-4p3ux5=""
+      size="xs"
+      style={
+        Object {
+          "fill": "lightGrey",
+          "height": 16,
+          "stroke": false,
+          "width": 16,
+        }
+      }
+    />
+  </div>
+  <div
     data-css-4p3ux5=""
     data-css-z169em=""
   >
@@ -142,6 +182,18 @@ exports[`Input component should render with all props 1`] = `
 `;
 
 exports[`Input component should render with required props only 1`] = `
+.css-1gnizwt,
+[data-css-1gnizwt] {
+  position: absolute;
+  top: 16px;
+  right: 15px;
+  pointer-events: none;
+  transition: opacity .225s;
+  opacity: 0;
+  -webkit-transition: opacity .225s;
+  -moz-transition: opacity .225s;
+}
+
 .css-13azwyo,
 [data-css-13azwyo] {
   position: relative;
@@ -154,8 +206,8 @@ exports[`Input component should render with required props only 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-14qrzmk,
-[data-css-14qrzmk] {
+.css-1e4vpa5,
+[data-css-1e4vpa5] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -172,16 +224,21 @@ exports[`Input component should render with required props only 1`] = `
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-14qrzmk:-webkit-autofill ~ div,
-[data-css-14qrzmk]:-webkit-autofill ~ div {
+.css-1e4vpa5:-webkit-autofill ~ .label,
+[data-css-1e4vpa5]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-14qrzmk:-webkit-autofill,
-[data-css-14qrzmk]:-webkit-autofill,
-.css-14qrzmk[data-simulate-webkitautofill],
-[data-css-14qrzmk][data-simulate-webkitautofill] {
+.css-1e4vpa5:-webkit-autofill ~ .checkmark,
+[data-css-1e4vpa5]:-webkit-autofill ~ .checkmark {
+  opacity: 1 !important;
+}
+
+.css-1e4vpa5:-webkit-autofill,
+[data-css-1e4vpa5]:-webkit-autofill,
+.css-1e4vpa5[data-simulate-webkitautofill],
+[data-css-1e4vpa5][data-simulate-webkitautofill] {
   padding-top: 10px !important;
 }
 
@@ -196,7 +253,7 @@ exports[`Input component should render with required props only 1`] = `
 >
   <input
     aria-required={false}
-    data-css-14qrzmk=""
+    data-css-1e4vpa5=""
     name="string"
     onInvalid={[Function]}
     onKeyUp={[Function]}
@@ -204,5 +261,28 @@ exports[`Input component should render with required props only 1`] = `
     required={false}
     type="text"
   />
+  <div
+    className="checkmark"
+    data-css-1gnizwt=""
+    data-css-4p3ux5=""
+  >
+    <div
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
+      data-css-4p3ux5=""
+      size="xs"
+      style={
+        Object {
+          "fill": "lightGrey",
+          "height": 16,
+          "stroke": false,
+          "width": 16,
+        }
+      }
+    />
+  </div>
 </div>
 `;

--- a/src/behaviour/__snapshots__/FormValidityProvider.test.jsx.snap
+++ b/src/behaviour/__snapshots__/FormValidityProvider.test.jsx.snap
@@ -112,8 +112,8 @@ exports[`Check FormValidityProvider should click on the button and get a custom 
   -webkit-flex: 0 0 auto;
 }
 
-.css-14qrzmk,
-[data-css-14qrzmk] {
+.css-1e4vpa5,
+[data-css-1e4vpa5] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -130,17 +130,34 @@ exports[`Check FormValidityProvider should click on the button and get a custom 
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-14qrzmk:-webkit-autofill ~ div,
-[data-css-14qrzmk]:-webkit-autofill ~ div {
+.css-1e4vpa5:-webkit-autofill ~ .label,
+[data-css-1e4vpa5]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-14qrzmk:-webkit-autofill,
-[data-css-14qrzmk]:-webkit-autofill,
-.css-14qrzmk[data-simulate-webkitautofill],
-[data-css-14qrzmk][data-simulate-webkitautofill] {
+.css-1e4vpa5:-webkit-autofill ~ .checkmark,
+[data-css-1e4vpa5]:-webkit-autofill ~ .checkmark {
+  opacity: 1 !important;
+}
+
+.css-1e4vpa5:-webkit-autofill,
+[data-css-1e4vpa5]:-webkit-autofill,
+.css-1e4vpa5[data-simulate-webkitautofill],
+[data-css-1e4vpa5][data-simulate-webkitautofill] {
   padding-top: 10px !important;
+}
+
+.css-1gnizwt,
+[data-css-1gnizwt] {
+  position: absolute;
+  top: 16px;
+  right: 15px;
+  pointer-events: none;
+  transition: opacity .225s;
+  opacity: 0;
+  -webkit-transition: opacity .225s;
+  -moz-transition: opacity .225s;
 }
 
 <form
@@ -191,7 +208,7 @@ exports[`Check FormValidityProvider should click on the button and get a custom 
     >
       <input
         aria-required={true}
-        data-css-14qrzmk=""
+        data-css-1e4vpa5=""
         name="email"
         onInvalid={[Function]}
         onKeyUp={[Function]}
@@ -199,6 +216,29 @@ exports[`Check FormValidityProvider should click on the button and get a custom 
         required={true}
         type="email"
       />
+      <div
+        className="checkmark"
+        data-css-1gnizwt=""
+        data-css-4p3ux5=""
+      >
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": undefined,
+            }
+          }
+          data-css-4p3ux5=""
+          size="xs"
+          style={
+            Object {
+              "fill": "lightGrey",
+              "height": 16,
+              "stroke": false,
+              "width": 16,
+            }
+          }
+        />
+      </div>
     </div>
   </div>
 </form>
@@ -343,8 +383,8 @@ exports[`Check FormValidityProvider should click on the button and get a custom 
   -webkit-flex: 0 0 auto;
 }
 
-.css-14qrzmk,
-[data-css-14qrzmk] {
+.css-1e4vpa5,
+[data-css-1e4vpa5] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -361,17 +401,34 @@ exports[`Check FormValidityProvider should click on the button and get a custom 
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-14qrzmk:-webkit-autofill ~ div,
-[data-css-14qrzmk]:-webkit-autofill ~ div {
+.css-1e4vpa5:-webkit-autofill ~ .label,
+[data-css-1e4vpa5]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-14qrzmk:-webkit-autofill,
-[data-css-14qrzmk]:-webkit-autofill,
-.css-14qrzmk[data-simulate-webkitautofill],
-[data-css-14qrzmk][data-simulate-webkitautofill] {
+.css-1e4vpa5:-webkit-autofill ~ .checkmark,
+[data-css-1e4vpa5]:-webkit-autofill ~ .checkmark {
+  opacity: 1 !important;
+}
+
+.css-1e4vpa5:-webkit-autofill,
+[data-css-1e4vpa5]:-webkit-autofill,
+.css-1e4vpa5[data-simulate-webkitautofill],
+[data-css-1e4vpa5][data-simulate-webkitautofill] {
   padding-top: 10px !important;
+}
+
+.css-1gnizwt,
+[data-css-1gnizwt] {
+  position: absolute;
+  top: 16px;
+  right: 15px;
+  pointer-events: none;
+  transition: opacity .225s;
+  opacity: 0;
+  -webkit-transition: opacity .225s;
+  -moz-transition: opacity .225s;
 }
 
 .css-1xcgwwg,
@@ -448,7 +505,7 @@ exports[`Check FormValidityProvider should click on the button and get a custom 
       </div>
       <input
         aria-required={true}
-        data-css-14qrzmk=""
+        data-css-1e4vpa5=""
         name="email"
         onInvalid={[Function]}
         onKeyUp={[Function]}
@@ -456,6 +513,29 @@ exports[`Check FormValidityProvider should click on the button and get a custom 
         required={true}
         type="email"
       />
+      <div
+        className="checkmark"
+        data-css-1gnizwt=""
+        data-css-4p3ux5=""
+      >
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": undefined,
+            }
+          }
+          data-css-4p3ux5=""
+          size="xs"
+          style={
+            Object {
+              "fill": "lightGrey",
+              "height": 16,
+              "stroke": false,
+              "width": 16,
+            }
+          }
+        />
+      </div>
     </div>
   </div>
 </form>
@@ -573,8 +653,8 @@ exports[`Check FormValidityProvider should click on the button and get a default
   -webkit-flex: 0 0 auto;
 }
 
-.css-14qrzmk,
-[data-css-14qrzmk] {
+.css-1e4vpa5,
+[data-css-1e4vpa5] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -591,17 +671,34 @@ exports[`Check FormValidityProvider should click on the button and get a default
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-14qrzmk:-webkit-autofill ~ div,
-[data-css-14qrzmk]:-webkit-autofill ~ div {
+.css-1e4vpa5:-webkit-autofill ~ .label,
+[data-css-1e4vpa5]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-14qrzmk:-webkit-autofill,
-[data-css-14qrzmk]:-webkit-autofill,
-.css-14qrzmk[data-simulate-webkitautofill],
-[data-css-14qrzmk][data-simulate-webkitautofill] {
+.css-1e4vpa5:-webkit-autofill ~ .checkmark,
+[data-css-1e4vpa5]:-webkit-autofill ~ .checkmark {
+  opacity: 1 !important;
+}
+
+.css-1e4vpa5:-webkit-autofill,
+[data-css-1e4vpa5]:-webkit-autofill,
+.css-1e4vpa5[data-simulate-webkitautofill],
+[data-css-1e4vpa5][data-simulate-webkitautofill] {
   padding-top: 10px !important;
+}
+
+.css-1gnizwt,
+[data-css-1gnizwt] {
+  position: absolute;
+  top: 16px;
+  right: 15px;
+  pointer-events: none;
+  transition: opacity .225s;
+  opacity: 0;
+  -webkit-transition: opacity .225s;
+  -moz-transition: opacity .225s;
 }
 
 <form
@@ -652,7 +749,7 @@ exports[`Check FormValidityProvider should click on the button and get a default
     >
       <input
         aria-required={true}
-        data-css-14qrzmk=""
+        data-css-1e4vpa5=""
         name="email"
         onInvalid={[Function]}
         onKeyUp={[Function]}
@@ -660,6 +757,29 @@ exports[`Check FormValidityProvider should click on the button and get a default
         required={true}
         type="email"
       />
+      <div
+        className="checkmark"
+        data-css-1gnizwt=""
+        data-css-4p3ux5=""
+      >
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": undefined,
+            }
+          }
+          data-css-4p3ux5=""
+          size="xs"
+          style={
+            Object {
+              "fill": "lightGrey",
+              "height": 16,
+              "stroke": false,
+              "width": 16,
+            }
+          }
+        />
+      </div>
     </div>
   </div>
 </form>
@@ -804,8 +924,8 @@ exports[`Check FormValidityProvider should click on the button and get a default
   -webkit-flex: 0 0 auto;
 }
 
-.css-14qrzmk,
-[data-css-14qrzmk] {
+.css-1e4vpa5,
+[data-css-1e4vpa5] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -822,17 +942,34 @@ exports[`Check FormValidityProvider should click on the button and get a default
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-14qrzmk:-webkit-autofill ~ div,
-[data-css-14qrzmk]:-webkit-autofill ~ div {
+.css-1e4vpa5:-webkit-autofill ~ .label,
+[data-css-1e4vpa5]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-14qrzmk:-webkit-autofill,
-[data-css-14qrzmk]:-webkit-autofill,
-.css-14qrzmk[data-simulate-webkitautofill],
-[data-css-14qrzmk][data-simulate-webkitautofill] {
+.css-1e4vpa5:-webkit-autofill ~ .checkmark,
+[data-css-1e4vpa5]:-webkit-autofill ~ .checkmark {
+  opacity: 1 !important;
+}
+
+.css-1e4vpa5:-webkit-autofill,
+[data-css-1e4vpa5]:-webkit-autofill,
+.css-1e4vpa5[data-simulate-webkitautofill],
+[data-css-1e4vpa5][data-simulate-webkitautofill] {
   padding-top: 10px !important;
+}
+
+.css-1gnizwt,
+[data-css-1gnizwt] {
+  position: absolute;
+  top: 16px;
+  right: 15px;
+  pointer-events: none;
+  transition: opacity .225s;
+  opacity: 0;
+  -webkit-transition: opacity .225s;
+  -moz-transition: opacity .225s;
 }
 
 .css-1xcgwwg,
@@ -909,7 +1046,7 @@ exports[`Check FormValidityProvider should click on the button and get a default
       </div>
       <input
         aria-required={true}
-        data-css-14qrzmk=""
+        data-css-1e4vpa5=""
         name="email"
         onInvalid={[Function]}
         onKeyUp={[Function]}
@@ -917,6 +1054,29 @@ exports[`Check FormValidityProvider should click on the button and get a default
         required={true}
         type="email"
       />
+      <div
+        className="checkmark"
+        data-css-1gnizwt=""
+        data-css-4p3ux5=""
+      >
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": undefined,
+            }
+          }
+          data-css-4p3ux5=""
+          size="xs"
+          style={
+            Object {
+              "fill": "lightGrey",
+              "height": 16,
+              "stroke": false,
+              "width": 16,
+            }
+          }
+        />
+      </div>
     </div>
   </div>
 </form>

--- a/src/molecules/__snapshots__/TextInput.test.js.snap
+++ b/src/molecules/__snapshots__/TextInput.test.js.snap
@@ -138,6 +138,7 @@ exports[`TextInput renders 1`] = `
       type="email"
     />
     <div
+      className="label"
       data-css-4p3ux5=""
       data-css-lwcmpf=""
       style={

--- a/src/molecules/__snapshots__/TextInput.test.js.snap
+++ b/src/molecules/__snapshots__/TextInput.test.js.snap
@@ -43,8 +43,8 @@ exports[`TextInput renders 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-14qrzmk,
-[data-css-14qrzmk] {
+.css-1e4vpa5,
+[data-css-1e4vpa5] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -61,17 +61,34 @@ exports[`TextInput renders 1`] = `
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-14qrzmk:-webkit-autofill ~ div,
-[data-css-14qrzmk]:-webkit-autofill ~ div {
+.css-1e4vpa5:-webkit-autofill ~ .label,
+[data-css-1e4vpa5]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-14qrzmk:-webkit-autofill,
-[data-css-14qrzmk]:-webkit-autofill,
-.css-14qrzmk[data-simulate-webkitautofill],
-[data-css-14qrzmk][data-simulate-webkitautofill] {
+.css-1e4vpa5:-webkit-autofill ~ .checkmark,
+[data-css-1e4vpa5]:-webkit-autofill ~ .checkmark {
+  opacity: 1 !important;
+}
+
+.css-1e4vpa5:-webkit-autofill,
+[data-css-1e4vpa5]:-webkit-autofill,
+.css-1e4vpa5[data-simulate-webkitautofill],
+[data-css-1e4vpa5][data-simulate-webkitautofill] {
   padding-top: 10px !important;
+}
+
+.css-1gnizwt,
+[data-css-1gnizwt] {
+  position: absolute;
+  top: 16px;
+  right: 15px;
+  pointer-events: none;
+  transition: opacity .225s;
+  opacity: 0;
+  -webkit-transition: opacity .225s;
+  -moz-transition: opacity .225s;
 }
 
 .css-13azwyo,
@@ -111,7 +128,7 @@ exports[`TextInput renders 1`] = `
   >
     <input
       aria-required={true}
-      data-css-14qrzmk=""
+      data-css-1e4vpa5=""
       name="email"
       onInvalid={[Function]}
       onKeyUp={[Function]}
@@ -138,6 +155,29 @@ exports[`TextInput renders 1`] = `
          
         *
       </div>
+    </div>
+    <div
+      className="checkmark"
+      data-css-1gnizwt=""
+      data-css-4p3ux5=""
+    >
+      <div
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": undefined,
+          }
+        }
+        data-css-4p3ux5=""
+        size="xs"
+        style={
+          Object {
+            "fill": "lightGrey",
+            "height": 16,
+            "stroke": false,
+            "width": 16,
+          }
+        }
+      />
     </div>
   </div>
 </div>

--- a/stories/FormStory.jsx
+++ b/stories/FormStory.jsx
@@ -54,6 +54,7 @@ export default class FormStory extends React.Component {
                       name="email"
                       label="E-Mail"
                       type="email"
+                      pattern="[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
                       placeholder="E-Mail"
                       required
                     />

--- a/stories/index.js
+++ b/stories/index.js
@@ -21,7 +21,7 @@ storiesOf('Animations', module)
 
 storiesOf('Forms', module)
   .addDecorator(createViewportDecorator())
-  .add('SimpelForm', () => <FormStory />)
+  .add('SimpleForm', () => <FormStory />)
 
 storiesOf('FloatingButton', module).add('with text', () => (
   <ThemeProvider>


### PR DESCRIPTION
**What has changed?**
* Show checkmark not only when `pattern` is passed but also when `minLength`, `maxLength` or `required` is passed.
* `&:-webkit-autofill ~ div` selector also selected the checkmark and applied `top: 8px` on it. This is solved by using class names on label/checkmark
* Use `opacity` on the checkmark to display/hide it. With this we can use the same technique to display the checkmark when it was autofilled ✌️
* Bonus: pass `required` to `textarea` as per spec it's a valid attribute.

Checklist:

- [x] Test added / Snapshots updated
- [ ] Documentation added / updated


