### PR TITLE
fixing example to re-enable documentation creation + allow readability

### DIFF
--- a/doc/reference/atoms/View.md
+++ b/doc/reference/atoms/View.md
@@ -31,4 +31,4 @@ For explanation see:
 |wrap|enum|Defining how children will wrap
 |flex|enum|Flex values, can be 5, 10, 15 ... 100 or 33, 66<br>Default: 'none'
 |onClick|func|
-|onRef|func|@deprecated<br>Default: _ => _
+|onRef|union|@deprecated<br>Default: _ => _

--- a/doc/reference/molecules/Collapsible.md
+++ b/doc/reference/molecules/Collapsible.md
@@ -6,79 +6,27 @@ You can change it in "src/molecules/Collapsible.jsx" and run build:docs to updat
 A Collapsible is a simple container, that makes it possible to change between collapsed and extended states, and this way hiding and showing the children passed in.
 ```example
 <ThemeProvider>
-  <ResourceProvider>
-    <Card
-      {...css({
-        width: '300px',
-        margin: '10px 10px 10px 10px',
-      })}
-    >
-      <Collapsible
-        title="Address"
-        hasBottomBorder
-        initiallyCollapsed={false}
-        tabIndex={1}
-      >
-        <View
-          direction="row"
-          {...css({
-            width: '300px',
-            padding: '5px 10px 10px 10px',
-          })}
-        >
-          <Icon
-            name="house"
-            color="grey"
-            {...css({ margin: '0px 20px 0px 30px' })}
-          />
-          <View direction="column">
-            <Text {...css({ width: '150px', margin: '2px 0px' })}>
-              Kaiser Joseph Str. 260
-            </Text>
-            <Text {...css({ width: '150px', margin: '2px 0px' })}>
-              Freiburg Im Breisgau
-            </Text>
-          </View>
-        </View>
-      </Collapsible>
-      <Collapsible
-        title="Contact"
-        initiallyCollapsed={true}
-        tabIndex={2}
-      >
-        <View
-          direction="column"
-          {...css({
-            width: '300px',
-            padding: '0px 10px 10px 10px',
-          })}
-        >
-          <View direction="row" {...css({ margin: '5px 0px' })}>
-            <Icon
-              name="phone"
-              color="grey"
-              {...css({ margin: '0px 20px 0px 30px' })}
-              size="s"
-            />
-            <Text {...css({ width: '150px', margin: '2px 0px' })}>
-              1(23) 456-7890
-            </Text>
-          </View>
-          <View direction="row" {...css({ margin: '5px 0px' })}>
-            <Icon
-              name="email"
-              color="grey"
-              {...css({ margin: '0px 20px 0px 30px' })}
-              size="s"
-            />
-            <Text {...css({ width: '150px', margin: '2px 0px' })}>
-              your@email.com
-            </Text>
-          </View>
-        </View>
-      </Collapsible>
-    </Card>
-  </ResourceProvider>
+ <Card>
+   <Collapsible
+     title="Address"
+     hasBottomBorder
+     initiallyCollapsed={false}
+     tabIndex={1}
+   >
+     <CardContent>
+       <Text>Kaiser Joseph Str. 260</Text>
+     </CardContent>
+   </Collapsible>
+   <Collapsible
+       title="Contact"
+       initiallyCollapsed={true}
+       tabIndex={2}
+   >
+     <CardContent>
+       <Text>1(23) 456-7890</Text>
+     </CardContent>
+   </Collapsible>
+ </Card>
 </ThemeProvider>
 ```
 ## Usage

--- a/src/molecules/Collapsible.jsx
+++ b/src/molecules/Collapsible.jsx
@@ -10,79 +10,27 @@ const tick = () => new Promise(resolve => setTimeout(resolve, 0))
  * A Collapsible is a simple container, that makes it possible to change between collapsed and extended states, and this way hiding and showing the children passed in.
  * ```example
  * <ThemeProvider>
- *   <ResourceProvider>
- *     <Card
- *       {...css({
- *         width: '300px',
- *         margin: '10px 10px 10px 10px',
- *       })}
- *     >
- *       <Collapsible
- *         title="Address"
- *         hasBottomBorder
- *         initiallyCollapsed={false}
- *         tabIndex={1}
- *       >
- *         <View
- *           direction="row"
- *           {...css({
- *             width: '300px',
- *             padding: '5px 10px 10px 10px',
- *           })}
- *         >
- *           <Icon
- *             name="house"
- *             color="grey"
- *             {...css({ margin: '0px 20px 0px 30px' })}
- *           />
- *           <View direction="column">
- *             <Text {...css({ width: '150px', margin: '2px 0px' })}>
- *               Kaiser Joseph Str. 260
- *             </Text>
- *             <Text {...css({ width: '150px', margin: '2px 0px' })}>
- *               Freiburg Im Breisgau
- *             </Text>
- *           </View>
- *         </View>
- *       </Collapsible>
- *       <Collapsible
- *         title="Contact"
- *         initiallyCollapsed={true}
- *         tabIndex={2}
- *       >
- *         <View
- *           direction="column"
- *           {...css({
- *             width: '300px',
- *             padding: '0px 10px 10px 10px',
- *           })}
- *         >
- *           <View direction="row" {...css({ margin: '5px 0px' })}>
- *             <Icon
- *               name="phone"
- *               color="grey"
- *               {...css({ margin: '0px 20px 0px 30px' })}
- *               size="s"
- *             />
- *             <Text {...css({ width: '150px', margin: '2px 0px' })}>
- *               1(23) 456-7890
- *             </Text>
- *           </View>
- *           <View direction="row" {...css({ margin: '5px 0px' })}>
- *             <Icon
- *               name="email"
- *               color="grey"
- *               {...css({ margin: '0px 20px 0px 30px' })}
- *               size="s"
- *             />
- *             <Text {...css({ width: '150px', margin: '2px 0px' })}>
- *               your@email.com
- *             </Text>
- *           </View>
- *         </View>
- *       </Collapsible>
- *     </Card>
- *   </ResourceProvider>
+ *  <Card>
+ *    <Collapsible
+ *      title="Address"
+ *      hasBottomBorder
+ *      initiallyCollapsed={false}
+ *      tabIndex={1}
+ *    >
+ *      <CardContent>
+ *        <Text>Kaiser Joseph Str. 260</Text>
+ *      </CardContent>
+ *    </Collapsible>
+ *    <Collapsible
+ *        title="Contact"
+ *        initiallyCollapsed={true}
+ *        tabIndex={2}
+ *    >
+ *      <CardContent>
+ *        <Text>1(23) 456-7890</Text>
+ *      </CardContent>
+ *    </Collapsible>
+ *  </Card>
  * </ThemeProvider>
  * ```
  **/


### PR DESCRIPTION
Documentation creation was failing because of the glamor ...css() calls in the example + it was quite hard to read for the end-user.

Documentation creation is still failing tho since the live-preview package in there is using an older react version which doesnt have the createRef API included - but thats a different story... 😄 

Checklist:

- [ ] Test added / Snapshots updated
- [x] Documentation added / updated


