### PR TITLE
fix: add name to checkbox

### DIFF
--- a/src/molecules/Checkbox.jsx
+++ b/src/molecules/Checkbox.jsx
@@ -96,6 +96,7 @@ class Checkbox extends React.Component {
                     type="checkbox"
                     checked={realChecked}
                     id={name}
+                    name={name}
                     value={realChecked}
                     style={{
                       opacity: 0,

--- a/src/molecules/__snapshots__/Checkbox.test.js.snap
+++ b/src/molecules/__snapshots__/Checkbox.test.js.snap
@@ -126,6 +126,7 @@ exports[`Test the checkbox component should tick it 1`] = `
         <input
           checked={false}
           id="a"
+          name="a"
           onChange={[Function]}
           style={
             Object {
@@ -314,6 +315,7 @@ exports[`Test the checkbox component should tick it 2`] = `
         <input
           checked={true}
           id="a"
+          name="a"
           onChange={[Function]}
           style={
             Object {
@@ -473,6 +475,7 @@ exports[`Test the checkbox component should work with children 1`] = `
         <input
           checked={false}
           id="a"
+          name="a"
           onChange={[Function]}
           style={
             Object {


### PR DESCRIPTION
before: checkbox's name attribute was missing, meaning form did not submit the checkbox's value
after: name is added so form submits checkbox's true/false also

Checklist:

- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


