### PR TITLE
fix: confirm always append to document.body

### DIFF
--- a/src/behaviour/Confirm.jsx
+++ b/src/behaviour/Confirm.jsx
@@ -3,21 +3,14 @@ import ReactDOM from 'react-dom'
 import ConfirmDialog from '../molecules/ConfirmDialog'
 import ThemeProvider from './ThemeProvider'
 
-const confirm = customization =>
+const confirm = ({ acceptButtonLabel, cancelButtonLabel, message }) =>
   new Promise(resolve => {
-    const {
-      acceptButtonLabel,
-      appendDialogTo,
-      cancelButtonLabel,
-      message,
-    } = customization
     const div = document.createElement('div')
-    const nodeToAppendTo = appendDialogTo || document.body
-    nodeToAppendTo.appendChild(div)
+    document.body.appendChild(div)
 
     const resolveAndClean = response => {
       ReactDOM.unmountComponentAtNode(div)
-      nodeToAppendTo.removeChild(div)
+      document.body.removeChild(div)
       resolve(response)
     }
 

--- a/stories/ConfirmStory.jsx
+++ b/stories/ConfirmStory.jsx
@@ -10,8 +10,8 @@ export default class FormStory extends React.Component {
   handleClick = async () => {
     const response = await confirm({
       message: 'Turn the background red?',
-      accept: 'Okidoki',
-      cancel: 'Nope',
+      acceptButtonLabel: 'Okidoki',
+      cancelButtonLabel: 'Nope',
     })
     const backgroundColor = response ? 'red' : 'white'
 


### PR DESCRIPTION
remove nodeToAppendTo param. result: confirm dialog will always appear in the middle of document.body

- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


