### PR TITLE
Fix/button background color

### DIFF
--- a/src/molecules/Button.jsx
+++ b/src/molecules/Button.jsx
@@ -34,9 +34,9 @@ function styles(
     ':hover': {
       background: disabled
         ? disabledBackgroundColor
-        : backgroundColor.includes('rgb')
-        ? backgroundColor
-        : col(backgroundColor, lightness(-10)),
+        : backgroundColor.includes('#')
+        ? col(backgroundColor, lightness(-10))
+        : backgroundColor,
     },
   })
 }

--- a/src/molecules/Button.jsx
+++ b/src/molecules/Button.jsx
@@ -34,7 +34,7 @@ function styles(
     ':hover': {
       background: disabled
         ? disabledBackgroundColor
-        : backgroundColor.includes('rgba')
+        : backgroundColor.includes('rgb')
         ? backgroundColor
         : col(backgroundColor, lightness(-10)),
     },

--- a/src/molecules/Button.jsx
+++ b/src/molecules/Button.jsx
@@ -34,7 +34,7 @@ function styles(
     ':hover': {
       background: disabled
         ? disabledBackgroundColor
-        : backgroundColor.includes('#')
+        : backgroundColor.indexOf('#') !== -1
         ? col(backgroundColor, lightness(-10))
         : backgroundColor,
     },

--- a/src/molecules/Button.jsx
+++ b/src/molecules/Button.jsx
@@ -34,6 +34,8 @@ function styles(
     ':hover': {
       background: disabled
         ? disabledBackgroundColor
+        : backgroundColor.includes('rgba')
+        ? backgroundColor
         : col(backgroundColor, lightness(-10)),
     },
   })

--- a/src/molecules/Card/CardButton.jsx
+++ b/src/molecules/Card/CardButton.jsx
@@ -15,7 +15,9 @@ const style = backgroundColor =>
     },
     ':hover': {
       cursor: 'pointer',
-      background: color(backgroundColor, lightness(-10)),
+      background: backgroundColor.includes('rgba')
+        ? backgroundColor
+        : color(backgroundColor, lightness(-10)),
     },
   })
 

--- a/src/molecules/Card/CardButton.jsx
+++ b/src/molecules/Card/CardButton.jsx
@@ -15,9 +15,9 @@ const style = backgroundColor =>
     },
     ':hover': {
       cursor: 'pointer',
-      background: backgroundColor.includes('rgb')
-        ? backgroundColor
-        : color(backgroundColor, lightness(-10)),
+      background: backgroundColor.includes('#')
+        ? color(backgroundColor, lightness(-10))
+        : backgroundColor,
     },
   })
 

--- a/src/molecules/Card/CardButton.jsx
+++ b/src/molecules/Card/CardButton.jsx
@@ -15,9 +15,10 @@ const style = backgroundColor =>
     },
     ':hover': {
       cursor: 'pointer',
-      background: backgroundColor.includes('#')
-        ? color(backgroundColor, lightness(-10))
-        : backgroundColor,
+      background:
+        backgroundColor.indexOf('#') !== -1
+          ? color(backgroundColor, lightness(-10))
+          : backgroundColor,
     },
   })
 

--- a/src/molecules/Card/CardButton.jsx
+++ b/src/molecules/Card/CardButton.jsx
@@ -15,7 +15,7 @@ const style = backgroundColor =>
     },
     ':hover': {
       cursor: 'pointer',
-      background: backgroundColor.includes('rgba')
+      background: backgroundColor.includes('rgb')
         ? backgroundColor
         : color(backgroundColor, lightness(-10)),
     },

--- a/src/molecules/FloatingButton.jsx
+++ b/src/molecules/FloatingButton.jsx
@@ -69,7 +69,7 @@ class FloatingButton extends React.Component {
             ':hover': {
               background: disabled
                 ? disabledColor
-                : color.includes('rgba')
+                : color.includes('rgb')
                 ? color
                 : col(color, lightness(-10)),
             },

--- a/src/molecules/FloatingButton.jsx
+++ b/src/molecules/FloatingButton.jsx
@@ -69,9 +69,9 @@ class FloatingButton extends React.Component {
             ':hover': {
               background: disabled
                 ? disabledColor
-                : color.includes('rgb')
-                ? color
-                : col(color, lightness(-10)),
+                : color.includes('#')
+                ? col(color, lightness(-10))
+                : color,
             },
           })}
         >

--- a/src/molecules/FloatingButton.jsx
+++ b/src/molecules/FloatingButton.jsx
@@ -69,7 +69,7 @@ class FloatingButton extends React.Component {
             ':hover': {
               background: disabled
                 ? disabledColor
-                : color.includes('#')
+                : color.indexOf('#') !== -1
                 ? col(color, lightness(-10))
                 : color,
             },

--- a/src/molecules/FloatingButton.jsx
+++ b/src/molecules/FloatingButton.jsx
@@ -67,7 +67,11 @@ class FloatingButton extends React.Component {
             transition: '250ms ease-in-out',
             width: '100%',
             ':hover': {
-              background: disabled ? disabledColor : col(color, lightness(-10)),
+              background: disabled
+                ? disabledColor
+                : color.includes('rgba')
+                ? color
+                : col(color, lightness(-10)),
             },
           })}
         >

--- a/src/molecules/__snapshots__/EditableText.test.jsx.snap
+++ b/src/molecules/__snapshots__/EditableText.test.jsx.snap
@@ -106,19 +106,19 @@ Snapshot Diff:
 @@ -3,22 +3,10 @@
     margin-left: 4px;
   }
-
+  
   .css-1,
   [data-css-1] {
 -   border-bottom: 1px dashed #95a5a5;
 - }
--
+- 
 - .css-1:focus,
 - [data-css-1]:focus,
 - .css-1[data-simulate-focus],
 - [data-css-1][data-simulate-focus] {
 -   border-bottom: 1px solid #95a5a5;
 - }
--
+- 
 - .css-5,
 - [data-css-5] {
     box-sizing: border-box;
@@ -131,7 +131,7 @@ Snapshot Diff:
     -webkit-justify-content: flex-start;
     -webkit-flex: 0 0 auto;
   }
-
+  
 - .css-6,
 - [data-css-6] {
 + .css-2,
@@ -143,7 +143,7 @@ Snapshot Diff:
     -moz-osx-font-smoothing: grayscale;
     color: #333333;
   }
-
+  
 - .css-7,
 - [data-css-7] {
 + .css-3,
@@ -152,19 +152,19 @@ Snapshot Diff:
     flex: 0 0 auto;
     -webkit-flex: 0 0 auto;
 + }
-+
++ 
 + .css-4,
 + [data-css-4] {
 +   border-bottom: 1px dashed #e84c3d;
 + }
-+
++ 
 + .css-4:focus,
 + [data-css-4]:focus,
 + .css-4[data-simulate-focus],
 + [data-css-4][data-simulate-focus] {
 +   border-bottom: 1px solid #e84c3d;
   }
-
+  
   <div
 -   data-css-5=""
 +   data-css-1=""

--- a/src/molecules/__snapshots__/EditableText.test.jsx.snap
+++ b/src/molecules/__snapshots__/EditableText.test.jsx.snap
@@ -151,8 +151,8 @@ Snapshot Diff:
     box-sizing: border-box;
     flex: 0 0 auto;
     -webkit-flex: 0 0 auto;
-+ }
-+ 
+  }
+  
 + .css-4,
 + [data-css-4] {
 +   border-bottom: 1px dashed #e84c3d;
@@ -163,8 +163,8 @@ Snapshot Diff:
 + .css-4[data-simulate-focus],
 + [data-css-4][data-simulate-focus] {
 +   border-bottom: 1px solid #e84c3d;
-  }
-  
++ }
++ 
   <div
 -   data-css-5=""
 +   data-css-1=""

--- a/src/molecules/__snapshots__/EditableText.test.jsx.snap
+++ b/src/molecules/__snapshots__/EditableText.test.jsx.snap
@@ -106,19 +106,19 @@ Snapshot Diff:
 @@ -3,22 +3,10 @@
     margin-left: 4px;
   }
-
+  
   .css-1,
   [data-css-1] {
 -   border-bottom: 1px dashed #95a5a5;
 - }
--
+- 
 - .css-1:focus,
 - [data-css-1]:focus,
 - .css-1[data-simulate-focus],
 - [data-css-1][data-simulate-focus] {
 -   border-bottom: 1px solid #95a5a5;
 - }
--
+- 
 - .css-5,
 - [data-css-5] {
     box-sizing: border-box;
@@ -131,7 +131,7 @@ Snapshot Diff:
     -webkit-justify-content: flex-start;
     -webkit-flex: 0 0 auto;
   }
-
+  
 - .css-6,
 - [data-css-6] {
 + .css-2,
@@ -143,7 +143,7 @@ Snapshot Diff:
     -moz-osx-font-smoothing: grayscale;
     color: #333333;
   }
-
+  
 - .css-7,
 - [data-css-7] {
 + .css-3,
@@ -151,20 +151,20 @@ Snapshot Diff:
     box-sizing: border-box;
     flex: 0 0 auto;
     -webkit-flex: 0 0 auto;
-+ }
-+
+  }
+  
 + .css-4,
 + [data-css-4] {
 +   border-bottom: 1px dashed #e84c3d;
 + }
-+
++ 
 + .css-4:focus,
 + [data-css-4]:focus,
 + .css-4[data-simulate-focus],
 + [data-css-4][data-simulate-focus] {
 +   border-bottom: 1px solid #e84c3d;
-  }
-
++ }
++ 
   <div
 -   data-css-5=""
 +   data-css-1=""

--- a/src/molecules/__snapshots__/EditableText.test.jsx.snap
+++ b/src/molecules/__snapshots__/EditableText.test.jsx.snap
@@ -106,19 +106,19 @@ Snapshot Diff:
 @@ -3,22 +3,10 @@
     margin-left: 4px;
   }
-  
+
   .css-1,
   [data-css-1] {
 -   border-bottom: 1px dashed #95a5a5;
 - }
-- 
+-
 - .css-1:focus,
 - [data-css-1]:focus,
 - .css-1[data-simulate-focus],
 - [data-css-1][data-simulate-focus] {
 -   border-bottom: 1px solid #95a5a5;
 - }
-- 
+-
 - .css-5,
 - [data-css-5] {
     box-sizing: border-box;
@@ -131,7 +131,7 @@ Snapshot Diff:
     -webkit-justify-content: flex-start;
     -webkit-flex: 0 0 auto;
   }
-  
+
 - .css-6,
 - [data-css-6] {
 + .css-2,
@@ -143,7 +143,7 @@ Snapshot Diff:
     -moz-osx-font-smoothing: grayscale;
     color: #333333;
   }
-  
+
 - .css-7,
 - [data-css-7] {
 + .css-3,
@@ -151,20 +151,20 @@ Snapshot Diff:
     box-sizing: border-box;
     flex: 0 0 auto;
     -webkit-flex: 0 0 auto;
-  }
-  
++ }
++
 + .css-4,
 + [data-css-4] {
 +   border-bottom: 1px dashed #e84c3d;
 + }
-+ 
++
 + .css-4:focus,
 + [data-css-4]:focus,
 + .css-4[data-simulate-focus],
 + [data-css-4][data-simulate-focus] {
 +   border-bottom: 1px solid #e84c3d;
-+ }
-+ 
+  }
+
   <div
 -   data-css-5=""
 +   data-css-1=""


### PR DESCRIPTION
I just realised `kewler` will break all our hero images / buttons where we pass `rgba()` or apparently even `rgb()` values with the last button update (PR #583)

Which makes partially sense... Since you cannot lighten/darken a transparent color (u basically can... but kewler can't :))

Soooo this is a hot fix to NOT break current implementations - it checks whether we pass a `rgb(a)` value (therefor no hover effect is added)


Checklist:

- [x] Test added / Snapshots updated
- [ ] Documentation added / updated

