### PR TITLE
fix: Spinner check typeof window

### DIFF
--- a/src/atoms/Spinner.jsx
+++ b/src/atoms/Spinner.jsx
@@ -42,7 +42,7 @@ const styles = (color, size) => ({
  */
 
 const Spinner = ({ color = ColorPalette.blue, size = 30 }) =>
-  isIE11(window && window.navigator.userAgent) ? (
+  isIE11(typeof window !== 'undefined' && window.navigator.userAgent) ? (
     <div {...css(styles(color, size).spinner)} />
   ) : (
     <svg


### PR DESCRIPTION
fix: SSR error `ReferenceError: window is not defined`. Check `typeof window` before passing in `window.navigation.userAgent` to helper function `isIE11()`

Checklist:

- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


