### PR TITLE
fix: Padding right on Typeahead and Input

### DIFF
--- a/doc/reference/atoms/Input.md
+++ b/doc/reference/atoms/Input.md
@@ -21,7 +21,8 @@ TextInputs are used to allow users to enter information like names, numbers, url
 |onChange|func|Called, when the user changes something
 |value|string|The value, makes this component a controlled component
 |lines|number|Can only be used with type=text. Increase to enable multi-line input<br>Default: 1
-|pattern|string|Regular expression to validate against
+|paddingRight|custom|Regular expression to validate against
+|pattern|string|Used when there is an icon to the right of input field
 |minLength|number|Min number of characters that must be provided
 |maxLength|number|Max number of characters that can be provided
 |onInputRef|func|Called with the input field a reference<br>Default: _ => _

--- a/doc/reference/atoms/Input.md
+++ b/doc/reference/atoms/Input.md
@@ -21,7 +21,7 @@ TextInputs are used to allow users to enter information like names, numbers, url
 |onChange|func|Called, when the user changes something
 |value|string|The value, makes this component a controlled component
 |lines|number|Can only be used with type=text. Increase to enable multi-line input<br>Default: 1
-|paddingRight|bool|Used when there is an icon to the right of input field
+|hasRightIcon|bool|Used when there is an icon to the right of input field
 |pattern|string|Regular expression to validate against
 |minLength|number|Min number of characters that must be provided
 |maxLength|number|Max number of characters that can be provided

--- a/doc/reference/atoms/Input.md
+++ b/doc/reference/atoms/Input.md
@@ -21,8 +21,8 @@ TextInputs are used to allow users to enter information like names, numbers, url
 |onChange|func|Called, when the user changes something
 |value|string|The value, makes this component a controlled component
 |lines|number|Can only be used with type=text. Increase to enable multi-line input<br>Default: 1
-|paddingRight|bool|Regular expression to validate against
-|pattern|string|Used when there is an icon to the right of input field
+|paddingRight|bool|Used when there is an icon to the right of input field
+|pattern|string|Regular expression to validate against
 |minLength|number|Min number of characters that must be provided
 |maxLength|number|Max number of characters that can be provided
 |onInputRef|func|Called with the input field a reference<br>Default: _ => _

--- a/doc/reference/atoms/Input.md
+++ b/doc/reference/atoms/Input.md
@@ -21,7 +21,7 @@ TextInputs are used to allow users to enter information like names, numbers, url
 |onChange|func|Called, when the user changes something
 |value|string|The value, makes this component a controlled component
 |lines|number|Can only be used with type=text. Increase to enable multi-line input<br>Default: 1
-|paddingRight|custom|Regular expression to validate against
+|paddingRight|bool|Regular expression to validate against
 |pattern|string|Used when there is an icon to the right of input field
 |minLength|number|Min number of characters that must be provided
 |maxLength|number|Max number of characters that can be provided

--- a/scripts/__snapshots__/example.test.js.snap
+++ b/scripts/__snapshots__/example.test.js.snap
@@ -1154,6 +1154,7 @@ exports[`Component Examples should match snapshot: Form0 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -2040,6 +2041,7 @@ exports[`Component Examples should match snapshot: Input0 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -2918,6 +2920,7 @@ exports[`Component Examples should match snapshot: PhoneInput0 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -4569,6 +4572,7 @@ exports[`Component Examples should match snapshot: TextInput0 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;

--- a/src/atoms/Input.jsx
+++ b/src/atoms/Input.jsx
@@ -8,7 +8,7 @@ import Icon, { Icons as AvailableIcons } from '../atoms/Icon'
 import Absolute from './Absolute'
 
 const styles = {
-  input: (showLabel, translated, checkmark) =>
+  input: (showLabel, translated, paddingRight) =>
     css(createTextStyles({ size: 'm' }), {
       boxSizing: 'border-box',
       height: 50,
@@ -16,7 +16,7 @@ const styles = {
       padding: '0 15px',
       paddingLeft: translated && 40,
       paddingTop: showLabel ? 10 : 0,
-      paddingRight: checkmark ? 50 : 15,
+      paddingRight: paddingRight ? 50 : 15,
       transition: 'padding-top .225s ease-out',
       border: 0,
       '&:-webkit-autofill ~ .label': {
@@ -136,6 +136,8 @@ class Input extends React.Component {
     /** Can only be used with type=text. Increase to enable multi-line input */
     lines: PropTypes.number,
     /** Regular expression to validate against */
+    paddingRight: PropTypes.boolean,
+    /** Used when there is an icon to the right of input field */
     pattern: PropTypes.string,
     /** Min number of characters that must be provided */
     minLength: PropTypes.number,
@@ -224,6 +226,7 @@ class Input extends React.Component {
       pattern,
       badInput,
       customError,
+      paddingRight,
       patternMismatch,
       rangeOverflow,
       rangeUnderflow,
@@ -263,7 +266,11 @@ class Input extends React.Component {
             )}
             <input
               ref={this.input}
-              {...styles.input(showLabel, !!icon, isCheckmarkActive)}
+              {...styles.input(
+                showLabel,
+                !!icon,
+                isCheckmarkActive || paddingRight
+              )}
               required={required}
               aria-required={required}
               {...props}

--- a/src/atoms/Input.jsx
+++ b/src/atoms/Input.jsx
@@ -16,7 +16,7 @@ const styles = {
       padding: '0 15px',
       paddingLeft: translated && 40,
       paddingTop: showLabel ? 10 : 0,
-      paddingRight: checkmark ? 50 : 0,
+      paddingRight: checkmark ? 50 : 15,
       transition: 'padding-top .225s ease-out',
       border: 0,
       '&:-webkit-autofill ~ .label': {

--- a/src/atoms/Input.jsx
+++ b/src/atoms/Input.jsx
@@ -135,9 +135,9 @@ class Input extends React.Component {
     value: PropTypes.string,
     /** Can only be used with type=text. Increase to enable multi-line input */
     lines: PropTypes.number,
-    /** Regular expression to validate against */
-    paddingRight: PropTypes.bool,
     /** Used when there is an icon to the right of input field */
+    paddingRight: PropTypes.bool,
+    /** Regular expression to validate against */
     pattern: PropTypes.string,
     /** Min number of characters that must be provided */
     minLength: PropTypes.number,

--- a/src/atoms/Input.jsx
+++ b/src/atoms/Input.jsx
@@ -136,7 +136,7 @@ class Input extends React.Component {
     /** Can only be used with type=text. Increase to enable multi-line input */
     lines: PropTypes.number,
     /** Used when there is an icon to the right of input field */
-    paddingRight: PropTypes.bool,
+    hasRightIcon: PropTypes.bool,
     /** Regular expression to validate against */
     pattern: PropTypes.string,
     /** Min number of characters that must be provided */
@@ -226,7 +226,7 @@ class Input extends React.Component {
       pattern,
       badInput,
       customError,
-      paddingRight,
+      hasRightIcon,
       patternMismatch,
       rangeOverflow,
       rangeUnderflow,
@@ -269,7 +269,7 @@ class Input extends React.Component {
               {...styles.input(
                 showLabel,
                 !!icon,
-                isCheckmarkActive || paddingRight
+                isCheckmarkActive || hasRightIcon
               )}
               required={required}
               aria-required={required}

--- a/src/atoms/Input.jsx
+++ b/src/atoms/Input.jsx
@@ -8,7 +8,7 @@ import Icon, { Icons as AvailableIcons } from '../atoms/Icon'
 import Absolute from './Absolute'
 
 const styles = {
-  input: (showLabel, translated) =>
+  input: (showLabel, translated, checkmark) =>
     css(createTextStyles({ size: 'm' }), {
       boxSizing: 'border-box',
       height: 50,
@@ -16,6 +16,7 @@ const styles = {
       padding: '0 15px',
       paddingLeft: translated && 40,
       paddingTop: showLabel ? 10 : 0,
+      paddingRight: checkmark ? 50 : 0,
       transition: 'padding-top .225s ease-out',
       border: 0,
       '&:-webkit-autofill ~ .label': {
@@ -262,7 +263,7 @@ class Input extends React.Component {
             )}
             <input
               ref={this.input}
-              {...styles.input(showLabel, !!icon)}
+              {...styles.input(showLabel, !!icon, isCheckmarkActive)}
               required={required}
               aria-required={required}
               {...props}

--- a/src/atoms/Input.jsx
+++ b/src/atoms/Input.jsx
@@ -136,7 +136,7 @@ class Input extends React.Component {
     /** Can only be used with type=text. Increase to enable multi-line input */
     lines: PropTypes.number,
     /** Regular expression to validate against */
-    paddingRight: PropTypes.boolean,
+    paddingRight: PropTypes.bool,
     /** Used when there is an icon to the right of input field */
     pattern: PropTypes.string,
     /** Min number of characters that must be provided */

--- a/src/atoms/__snapshots__/Input.test.jsx.snap
+++ b/src/atoms/__snapshots__/Input.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`Input component should render with all props 1`] = `
   padding: 0 15px;
   padding-left: 40px;
   padding-top: 10px;
-  padding-right: 15px;
+  padding-right: 50px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;

--- a/src/atoms/__snapshots__/Input.test.jsx.snap
+++ b/src/atoms/__snapshots__/Input.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`Input component should render with all props 1`] = `
   padding: 0 15px;
   padding-left: 40px;
   padding-top: 10px;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -275,6 +276,7 @@ exports[`Input component should render with required props only 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;

--- a/src/molecules/__snapshots__/TextInput.test.js.snap
+++ b/src/molecules/__snapshots__/TextInput.test.js.snap
@@ -44,6 +44,7 @@ exports[`TextInput renders 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;

--- a/src/organisms/Dropdown.jsx
+++ b/src/organisms/Dropdown.jsx
@@ -157,7 +157,7 @@ export default class Dropdown extends React.PureComponent {
                     value={(selectedItem && selectedItem.label) || ''}
                     readOnly
                     name={name}
-                    paddingRight
+                    hasRightIcon
                     {...css({
                       width: 'calc(100% - 5px)',
                       textOverflow: 'ellipsis',

--- a/src/organisms/Dropdown.jsx
+++ b/src/organisms/Dropdown.jsx
@@ -157,6 +157,7 @@ export default class Dropdown extends React.PureComponent {
                     value={(selectedItem && selectedItem.label) || ''}
                     readOnly
                     name={name}
+                    paddingRight
                     {...css({
                       width: 'calc(100% - 5px)',
                       textOverflow: 'ellipsis',

--- a/src/organisms/Typeahead.jsx
+++ b/src/organisms/Typeahead.jsx
@@ -368,7 +368,7 @@ export default class Typeahead extends React.PureComponent {
                             })
                           : ''
                       }
-                      paddingRight={!selectedItem && !!clearOnSelect}
+                      hasRightIcon={!selectedItem && !!clearOnSelect}
                       {...css({
                         background: '#fff',
                         border: 'none',
@@ -383,7 +383,7 @@ export default class Typeahead extends React.PureComponent {
                     name="typed"
                     onClick={autoOpen && !selectedItem ? toggleMenu : undefined}
                     onInputRef={this.setInputRef}
-                    paddingRight={!selectedItem && !!clearOnSelect}
+                    hasRightIcon={!selectedItem && !!clearOnSelect}
                     placeholder={placeholder}
                     {...getInputProps({
                       onKeyDown: e => {

--- a/src/organisms/Typeahead.jsx
+++ b/src/organisms/Typeahead.jsx
@@ -374,6 +374,7 @@ export default class Typeahead extends React.PureComponent {
                         boxShadow: 'none',
                         color: '#999',
                         opacity: 1,
+                        paddingRight: '50px',
                         height: INPUT_FIELD_HEIGHT,
                       })}
                     />
@@ -406,6 +407,7 @@ export default class Typeahead extends React.PureComponent {
                       boxShadow: 'none',
                       color: '#000',
                       outline: 'none',
+                      paddingRight: '50px',
                       width: '100%',
                       height: INPUT_FIELD_HEIGHT,
                     })}

--- a/src/organisms/Typeahead.jsx
+++ b/src/organisms/Typeahead.jsx
@@ -374,7 +374,7 @@ export default class Typeahead extends React.PureComponent {
                         boxShadow: 'none',
                         color: '#999',
                         opacity: 1,
-                        paddingRight: '50px',
+                        paddingRight: '50px !important',
                         height: INPUT_FIELD_HEIGHT,
                       })}
                     />
@@ -407,7 +407,7 @@ export default class Typeahead extends React.PureComponent {
                       boxShadow: 'none',
                       color: '#000',
                       outline: 'none',
-                      paddingRight: '50px',
+                      paddingRight: '50px !important',
                       width: '100%',
                       height: INPUT_FIELD_HEIGHT,
                     })}

--- a/src/organisms/Typeahead.jsx
+++ b/src/organisms/Typeahead.jsx
@@ -383,6 +383,7 @@ export default class Typeahead extends React.PureComponent {
                     name="typed"
                     onClick={autoOpen && !selectedItem ? toggleMenu : undefined}
                     onInputRef={this.setInputRef}
+                    paddingRight={!selectedItem && !!clearOnSelect}
                     placeholder={placeholder}
                     {...getInputProps({
                       onKeyDown: e => {
@@ -407,7 +408,6 @@ export default class Typeahead extends React.PureComponent {
                       boxShadow: 'none',
                       color: '#000',
                       outline: 'none',
-                      paddingRight: '50px !important',
                       width: '100%',
                       height: INPUT_FIELD_HEIGHT,
                     })}

--- a/src/organisms/Typeahead.jsx
+++ b/src/organisms/Typeahead.jsx
@@ -368,13 +368,13 @@ export default class Typeahead extends React.PureComponent {
                             })
                           : ''
                       }
+                      paddingRight={!selectedItem && !!clearOnSelect}
                       {...css({
                         background: '#fff',
                         border: 'none',
                         boxShadow: 'none',
                         color: '#999',
                         opacity: 1,
-                        paddingRight: '50px !important',
                         height: INPUT_FIELD_HEIGHT,
                       })}
                     />

--- a/src/organisms/__snapshots__/Dropdown.test.jsx.snap
+++ b/src/organisms/__snapshots__/Dropdown.test.jsx.snap
@@ -84,7 +84,7 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 10px;
-  padding-right: 15px;
+  padding-right: 50px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -165,8 +165,8 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
       >
         <input
           aria-required={false}
-          data-css-7=""
           data-css-4=""
+          data-css-7=""
           disabled={true}
           onChange={[Function]}
           placeholder="select something..."
@@ -333,7 +333,7 @@ exports[`Dropdown should render with placement top 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 10px;
-  padding-right: 15px;
+  padding-right: 50px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -414,8 +414,8 @@ exports[`Dropdown should render with placement top 1`] = `
       >
         <input
           aria-required={false}
-          data-css-7=""
           data-css-4=""
+          data-css-7=""
           disabled={true}
           onChange={[Function]}
           placeholder="select something..."

--- a/src/organisms/__snapshots__/Dropdown.test.jsx.snap
+++ b/src/organisms/__snapshots__/Dropdown.test.jsx.snap
@@ -84,6 +84,7 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 10px;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -164,8 +165,8 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
       >
         <input
           aria-required={false}
-          data-css-4=""
           data-css-7=""
+          data-css-4=""
           disabled={true}
           onChange={[Function]}
           placeholder="select something..."
@@ -332,6 +333,7 @@ exports[`Dropdown should render with placement top 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 10px;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -412,8 +414,8 @@ exports[`Dropdown should render with placement top 1`] = `
       >
         <input
           aria-required={false}
-          data-css-4=""
           data-css-7=""
+          data-css-4=""
           disabled={true}
           onChange={[Function]}
           placeholder="select something..."

--- a/src/organisms/__snapshots__/Typeahead.test.jsx.snap
+++ b/src/organisms/__snapshots__/Typeahead.test.jsx.snap
@@ -62,7 +62,6 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
   box-shadow: none;
   color: #000;
   outline: none;
-  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -359,7 +358,6 @@ exports[`Test the typeahead component should be a simple static one - in depth t
   box-shadow: none;
   color: #000;
   outline: none;
-  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -756,7 +754,6 @@ exports[`Test the typeahead component should be a simple static one which auto o
   box-shadow: none;
   color: #000;
   outline: none;
-  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -1276,7 +1273,6 @@ exports[`Test the typeahead component should render differently when loading 1`]
   box-shadow: none;
   color: #000;
   outline: none;
-  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -1574,7 +1570,6 @@ exports[`Test the typeahead component should render differently when loading 2`]
   box-shadow: none;
   color: #000;
   outline: none;
-  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -2020,7 +2015,6 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   box-shadow: none;
   color: #000;
   outline: none;
-  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -2464,7 +2458,6 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   box-shadow: none;
   color: #000;
   outline: none;
-  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }

--- a/src/organisms/__snapshots__/Typeahead.test.jsx.snap
+++ b/src/organisms/__snapshots__/Typeahead.test.jsx.snap
@@ -52,7 +52,6 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
   box-shadow: none;
   color: #999;
   opacity: 1;
-  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -350,7 +349,6 @@ exports[`Test the typeahead component should be a simple static one - in depth t
   box-shadow: none;
   color: #999;
   opacity: 1;
-  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -628,7 +626,6 @@ exports[`Test the typeahead component should be a simple static one which auto o
   box-shadow: none;
   color: #999;
   opacity: 1;
-  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -1269,7 +1266,6 @@ exports[`Test the typeahead component should render differently when loading 1`]
   box-shadow: none;
   color: #999;
   opacity: 1;
-  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -1568,7 +1564,6 @@ exports[`Test the typeahead component should render differently when loading 2`]
   box-shadow: none;
   color: #999;
   opacity: 1;
-  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -1895,7 +1890,6 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   box-shadow: none;
   color: #999;
   opacity: 1;
-  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -2340,7 +2334,6 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   box-shadow: none;
   color: #999;
   opacity: 1;
-  padding-right: 50px !important;
   height: 50px;
 }
 

--- a/src/organisms/__snapshots__/Typeahead.test.jsx.snap
+++ b/src/organisms/__snapshots__/Typeahead.test.jsx.snap
@@ -52,6 +52,7 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
   box-shadow: none;
   color: #999;
   opacity: 1;
+  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -62,6 +63,7 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
   box-shadow: none;
   color: #000;
   outline: none;
+  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -97,6 +99,7 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -347,6 +350,7 @@ exports[`Test the typeahead component should be a simple static one - in depth t
   box-shadow: none;
   color: #999;
   opacity: 1;
+  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -357,6 +361,7 @@ exports[`Test the typeahead component should be a simple static one - in depth t
   box-shadow: none;
   color: #000;
   outline: none;
+  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -392,6 +397,7 @@ exports[`Test the typeahead component should be a simple static one - in depth t
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -622,6 +628,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
   box-shadow: none;
   color: #999;
   opacity: 1;
+  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -656,6 +663,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -751,6 +759,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
   box-shadow: none;
   color: #000;
   outline: none;
+  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -1260,6 +1269,7 @@ exports[`Test the typeahead component should render differently when loading 1`]
   box-shadow: none;
   color: #999;
   opacity: 1;
+  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -1270,6 +1280,7 @@ exports[`Test the typeahead component should render differently when loading 1`]
   box-shadow: none;
   color: #000;
   outline: none;
+  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -1305,6 +1316,7 @@ exports[`Test the typeahead component should render differently when loading 1`]
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -1556,6 +1568,7 @@ exports[`Test the typeahead component should render differently when loading 2`]
   box-shadow: none;
   color: #999;
   opacity: 1;
+  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -1566,6 +1579,7 @@ exports[`Test the typeahead component should render differently when loading 2`]
   box-shadow: none;
   color: #000;
   outline: none;
+  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -1601,6 +1615,7 @@ exports[`Test the typeahead component should render differently when loading 2`]
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -1880,6 +1895,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   box-shadow: none;
   color: #999;
   opacity: 1;
+  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -1914,6 +1930,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -2009,6 +2026,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   box-shadow: none;
   color: #000;
   outline: none;
+  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }
@@ -2322,6 +2340,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   box-shadow: none;
   color: #999;
   opacity: 1;
+  padding-right: 50px !important;
   height: 50px;
 }
 
@@ -2356,6 +2375,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -2451,6 +2471,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   box-shadow: none;
   color: #000;
   outline: none;
+  padding-right: 50px !important;
   width: 100%;
   height: 50px;
 }


### PR DESCRIPTION
adjust Typeahead and Input to not overlap icons

Checklist:

- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


