### PR TITLE
set background color on input for IE11

### DIFF
--- a/src/organisms/Dropdown.jsx
+++ b/src/organisms/Dropdown.jsx
@@ -167,6 +167,7 @@ export default class Dropdown extends React.PureComponent {
                       paddingRight: '30px',
                       color: 'black',
                       backgroundColor: 'white',
+                      pointerEvents: 'none',
                     })}
                   />
 

--- a/src/organisms/Dropdown.jsx
+++ b/src/organisms/Dropdown.jsx
@@ -166,6 +166,7 @@ export default class Dropdown extends React.PureComponent {
                       cursor: 'pointer',
                       paddingRight: '30px',
                       color: 'black',
+                      backgroundColor: 'white',
                     })}
                   />
 

--- a/src/organisms/__snapshots__/Dropdown.test.jsx.snap
+++ b/src/organisms/__snapshots__/Dropdown.test.jsx.snap
@@ -55,6 +55,7 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
   cursor: pointer;
   padding-right: 30px;
   color: black;
+  background-color: white;
 }
 
 .css-5,
@@ -304,6 +305,7 @@ exports[`Dropdown should render with placement top 1`] = `
   cursor: pointer;
   padding-right: 30px;
   color: black;
+  background-color: white;
 }
 
 .css-5,

--- a/src/organisms/__snapshots__/Dropdown.test.jsx.snap
+++ b/src/organisms/__snapshots__/Dropdown.test.jsx.snap
@@ -56,6 +56,7 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
   padding-right: 30px;
   color: black;
   background-color: white;
+  pointer-events: none;
 }
 
 .css-5,
@@ -306,6 +307,7 @@ exports[`Dropdown should render with placement top 1`] = `
   padding-right: 30px;
   color: black;
   background-color: white;
+  pointer-events: none;
 }
 
 .css-5,


### PR DESCRIPTION
Fixing the background color in Dropdown input for IE11. See screenshots below:

Before:
<img width="296" alt="Bildschirmfoto 2019-05-17 um 10 07 52" src="https://user-images.githubusercontent.com/4015313/57912911-c0168780-788b-11e9-817a-0a2997462e19.png">

After:
<img width="297" alt="Bildschirmfoto 2019-05-17 um 10 08 03" src="https://user-images.githubusercontent.com/4015313/57912912-c0168780-788b-11e9-9231-dc84a72f8660.png">


- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


