### PR TITLE
fix: Typeahead right padding condition wrong

### DIFF
--- a/src/organisms/Typeahead.jsx
+++ b/src/organisms/Typeahead.jsx
@@ -368,7 +368,7 @@ export default class Typeahead extends React.PureComponent {
                             })
                           : ''
                       }
-                      hasRightIcon={!selectedItem && !!clearOnSelect}
+                      hasRightIcon={!selectedItem && !clearOnSelect}
                       {...css({
                         background: '#fff',
                         border: 'none',
@@ -383,7 +383,7 @@ export default class Typeahead extends React.PureComponent {
                     name="typed"
                     onClick={autoOpen && !selectedItem ? toggleMenu : undefined}
                     onInputRef={this.setInputRef}
-                    hasRightIcon={!selectedItem && !!clearOnSelect}
+                    hasRightIcon={!selectedItem && !clearOnSelect}
                     placeholder={placeholder}
                     {...getInputProps({
                       onKeyDown: e => {

--- a/src/organisms/__snapshots__/Typeahead.test.jsx.snap
+++ b/src/organisms/__snapshots__/Typeahead.test.jsx.snap
@@ -97,7 +97,7 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 15px;
+  padding-right: 50px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -393,7 +393,7 @@ exports[`Test the typeahead component should be a simple static one - in depth t
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 15px;
+  padding-right: 50px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -658,7 +658,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 15px;
+  padding-right: 50px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -1308,7 +1308,7 @@ exports[`Test the typeahead component should render differently when loading 1`]
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 15px;
+  padding-right: 50px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -1605,7 +1605,7 @@ exports[`Test the typeahead component should render differently when loading 2`]
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 15px;
+  padding-right: 50px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -1919,7 +1919,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 15px;
+  padding-right: 50px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -2362,7 +2362,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 15px;
+  padding-right: 50px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;


### PR DESCRIPTION
Typeahead's `Input`'s `hasRightIcon` prop is only true when `clearOnSelect` is true. This should be false.

Checklist:

- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


