### PR TITLE
fix: Typeahead add right padding when item is selected

### DIFF
--- a/src/organisms/Typeahead.jsx
+++ b/src/organisms/Typeahead.jsx
@@ -368,7 +368,7 @@ export default class Typeahead extends React.PureComponent {
                             })
                           : ''
                       }
-                      hasRightIcon={!selectedItem && !clearOnSelect}
+                      hasRightIcon={selectedItem && !clearOnSelect}
                       {...css({
                         background: '#fff',
                         border: 'none',
@@ -383,7 +383,7 @@ export default class Typeahead extends React.PureComponent {
                     name="typed"
                     onClick={autoOpen && !selectedItem ? toggleMenu : undefined}
                     onInputRef={this.setInputRef}
-                    hasRightIcon={!selectedItem && !clearOnSelect}
+                    hasRightIcon={selectedItem && !clearOnSelect}
                     placeholder={placeholder}
                     {...getInputProps({
                       onKeyDown: e => {

--- a/src/organisms/Typeahead.jsx
+++ b/src/organisms/Typeahead.jsx
@@ -380,6 +380,7 @@ export default class Typeahead extends React.PureComponent {
                     />
                   </Absolute>
                   <Input
+                    data-e2e={this.props['data-e2e']}
                     name="typed"
                     onClick={autoOpen && !selectedItem ? toggleMenu : undefined}
                     onInputRef={this.setInputRef}

--- a/src/organisms/Typeahead.jsx
+++ b/src/organisms/Typeahead.jsx
@@ -368,7 +368,7 @@ export default class Typeahead extends React.PureComponent {
                             })
                           : ''
                       }
-                      hasRightIcon={selectedItem && !clearOnSelect}
+                      hasRightIcon={!!selectedItem && !clearOnSelect}
                       {...css({
                         background: '#fff',
                         border: 'none',
@@ -383,7 +383,7 @@ export default class Typeahead extends React.PureComponent {
                     name="typed"
                     onClick={autoOpen && !selectedItem ? toggleMenu : undefined}
                     onInputRef={this.setInputRef}
-                    hasRightIcon={selectedItem && !clearOnSelect}
+                    hasRightIcon={!!selectedItem && !clearOnSelect}
                     placeholder={placeholder}
                     {...getInputProps({
                       onKeyDown: e => {

--- a/src/organisms/Typeahead.jsx
+++ b/src/organisms/Typeahead.jsx
@@ -380,7 +380,6 @@ export default class Typeahead extends React.PureComponent {
                     />
                   </Absolute>
                   <Input
-                    data-e2e={this.props['data-e2e']}
                     name="typed"
                     onClick={autoOpen && !selectedItem ? toggleMenu : undefined}
                     onInputRef={this.setInputRef}

--- a/src/organisms/Typeahead.test.jsx
+++ b/src/organisms/Typeahead.test.jsx
@@ -160,6 +160,7 @@ describe('Test the typeahead component', () => {
       />
     )
     expect(wrapper.find(INPUT(5)).prop('value')).toBe(DEFAULT_VALUE)
+    expect(wrapper).toMatchSnapshot()
   })
   it('should use the value property (controlled component)', () => {
     const wrapper = mount(

--- a/src/organisms/__snapshots__/Typeahead.test.jsx.snap
+++ b/src/organisms/__snapshots__/Typeahead.test.jsx.snap
@@ -97,7 +97,7 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 50px;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -393,7 +393,7 @@ exports[`Test the typeahead component should be a simple static one - in depth t
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 50px;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -658,7 +658,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 50px;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -1308,7 +1308,7 @@ exports[`Test the typeahead component should render differently when loading 1`]
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 50px;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -1605,7 +1605,7 @@ exports[`Test the typeahead component should render differently when loading 2`]
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 50px;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -1919,7 +1919,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 50px;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;
@@ -2362,7 +2362,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   width: 100%;
   padding: 0 15px;
   padding-top: 0;
-  padding-right: 50px;
+  padding-right: 15px;
   transition: padding-top .225s ease-out;
   border: 0;
   -webkit-transition: padding-top .225s ease-out;

--- a/src/organisms/__snapshots__/Typeahead.test.jsx.snap
+++ b/src/organisms/__snapshots__/Typeahead.test.jsx.snap
@@ -1853,6 +1853,353 @@ exports[`Test the typeahead component should render differently when loading 2`]
 </div>
 `;
 
+exports[`Test the typeahead component should use the defaultValue property (uncontrolled component) 1`] = `
+.css-0,
+[data-css-0] {
+  position: relative;
+}
+
+.css-1,
+[data-css-1] {
+  align-items: stretch;
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  width: 100%;
+  -webkit-box-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+}
+
+.css-2,
+[data-css-2] {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background-color: #FFF;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+}
+
+.css-3,
+[data-css-3] {
+  width: 100%;
+}
+
+.css-4,
+[data-css-4] {
+  background: #fff;
+  border: none;
+  box-shadow: none;
+  color: #999;
+  opacity: 1;
+  height: 50px;
+}
+
+.css-5,
+[data-css-5] {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: #000;
+  outline: none;
+  width: 100%;
+  height: 50px;
+}
+
+.css-6,
+[data-css-6] {
+  height: 100%;
+}
+
+.css-7,
+[data-css-7] {
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  -webkit-flex: 0 0 auto;
+}
+
+.css-8,
+[data-css-8] {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.css-9,
+[data-css-9] {
+  position: absolute;
+  top: 16px;
+  right: 15px;
+  pointer-events: none;
+  transition: opacity .225s;
+  opacity: 0;
+  -webkit-transition: opacity .225s;
+  -moz-transition: opacity .225s;
+}
+
+.css-10,
+[data-css-10] {
+  position: absolute;
+  top: 0;
+  right: 20px;
+}
+
+.css-11,
+[data-css-11] {
+  box-sizing: border-box;
+  align-content: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  flex: 0 0 auto;
+  -webkit-align-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -webkit-flex: 0 0 auto;
+}
+
+.css-12,
+[data-css-12] {
+  width: 100%;
+}
+
+.css-12:after,
+[data-css-12]:after {
+  background: -webkit-linear-gradient(to right, rgba(0,0,0,0) 0%,rgba(192,192,192,0) 52%,rgba(244,244,244,0) 66%,rgba(255,255,255,0.6) 81%,rgba(255,255,255,1) 88%,rgba(255,255,255,1) 100%);
+  background: -moz-linear-gradient(to right, rgba(0,0,0,0) 0%,rgba(192,192,192,0) 52%,rgba(244,244,244,0) 66%,rgba(255,255,255,0.6) 81%,rgba(255,255,255,1) 88%,rgba(255,255,255,1) 100%);
+  background: linear-gradient(to right, rgba(0,0,0,0) 0%,rgba(192,192,192,0) 52%,rgba(244,244,244,0) 66%,rgba(255,255,255,0.6) 81%,rgba(255,255,255,1) 88%,rgba(255,255,255,1) 100%);
+  bottom: 0;
+  content: '';
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+}
+
+.css-14,
+[data-css-14] {
+  cursor: pointer;
+  margin: -10px;
+  padding: 10px;
+  transform: translateY(-3px);
+  z-index: 1;
+  -webkit-transform: translateY(-3px);
+}
+
+.css-15,
+[data-css-15] {
+  display: inline;
+  font-family: "Open Sans", Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  box-sizing: border-box;
+  height: 50px;
+  width: 100%;
+  padding: 0 15px;
+  padding-top: 0;
+  padding-right: 50px;
+  transition: padding-top .225s ease-out;
+  border: 0;
+  -webkit-transition: padding-top .225s ease-out;
+  -moz-transition: padding-top .225s ease-out;
+}
+
+.css-15:-webkit-autofill ~ .label,
+[data-css-15]:-webkit-autofill ~ .label {
+  opacity: 1 !important;
+  top: 8px !important;
+}
+
+.css-15:-webkit-autofill ~ .checkmark,
+[data-css-15]:-webkit-autofill ~ .checkmark {
+  opacity: 1 !important;
+  top: 8px;
+}
+
+.css-15:-webkit-autofill,
+[data-css-15]:-webkit-autofill {
+  padding-top: 10px !important;
+}
+
+<div
+  aria-expanded={false}
+  aria-haspopup="listbox"
+  aria-labelledby="downshift-5-label"
+  aria-owns={null}
+  data-css-1=""
+  role="combobox"
+>
+  <div
+    data-css-7=""
+    data-css-2=""
+  >
+    <div
+      data-css-0=""
+      data-css-12=""
+      data-css-7=""
+    >
+      <div
+        data-css-7=""
+        data-css-3=""
+        data-css-8=""
+      >
+        <div
+          data-css-0=""
+          data-css-7=""
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
+        >
+          <input
+            aria-required={false}
+            autoComplete="off"
+            data-css-4=""
+            data-css-15=""
+            name="hint"
+            onChange={[Function]}
+            required={false}
+            tabIndex={-1}
+            type="text"
+            value="Abomasnow"
+          />
+          <div
+            className="checkmark"
+            data-css-9=""
+            data-css-7=""
+          >
+            <div
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": undefined,
+                }
+              }
+              data-css-7=""
+              style={
+                Object {
+                  "fill": "lightGrey",
+                  "height": 16,
+                  "stroke": false,
+                  "width": 16,
+                }
+              }
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        data-css-0=""
+        data-css-7=""
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
+      >
+        <input
+          aria-activedescendant={null}
+          aria-autocomplete="list"
+          aria-controls={null}
+          aria-labelledby="downshift-5-label"
+          aria-required={false}
+          autoComplete="off"
+          data-css-5=""
+          data-css-15=""
+          id="downshift-5-input"
+          name="typed"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          placeholder="Select Nick's Pokemon"
+          required={false}
+          type="text"
+          value="Abomasnow"
+        />
+        <div
+          className="checkmark"
+          data-css-9=""
+          data-css-7=""
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": undefined,
+              }
+            }
+            data-css-7=""
+            style={
+              Object {
+                "fill": "lightGrey",
+                "height": 16,
+                "stroke": false,
+                "width": 16,
+              }
+            }
+          />
+        </div>
+      </div>
+      <div
+        data-css-10=""
+        data-css-11=""
+        data-css-6=""
+      >
+        <div
+          data-css-7=""
+          data-css-14=""
+          onClick={[Function]}
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": undefined,
+              }
+            }
+            data-css-7=""
+            style={
+              Object {
+                "fill": "black",
+                "height": 10,
+                "stroke": false,
+                "width": 10,
+              }
+            }
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-css-0=""
+    data-css-7=""
+  />
+</div>
+`;
+
 exports[`Test the typeahead component should use the limit property 1`] = `
 .css-0,
 [data-css-0] {


### PR DESCRIPTION
bug: no right padding is added when an item from the dropdown is selected, leading to overlapping of text and "x" icon

fix: add right padding when item is selected

Checklist:

- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


