### PR TITLE
Resolves APP-3810: IE/App: typeahead needs some fixin’

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -3,7 +3,7 @@ module.exports = ({ config }) => {
     test: /\.(ts|tsx)$/,
     use: [
       {
-        loader: require.resolve('awesome-typescript-loader'),
+        loader: 'awesome-typescript-loader?target=es5',
       },
     ],
   })

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -3,7 +3,7 @@ module.exports = ({ config }) => {
     test: /\.(ts|tsx)$/,
     use: [
       {
-        loader: require.resolve('awesome-typescript-loader?target=es5'),
+        loader: require.resolve('awesome-typescript-loader'),
       },
     ],
   })

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -3,7 +3,7 @@ module.exports = ({ config }) => {
     test: /\.(ts|tsx)$/,
     use: [
       {
-        loader: require.resolve('awesome-typescript-loader'),
+        loader: require.resolve('awesome-typescript-loader?target=es5'),
       },
     ],
   })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "terser": ">=3.16.1",
     "lodash": ">=4.17.2",
     "set-value": ">=3.0.1",
-    "mixin-deep": ">=2.0.1"
+    "mixin-deep": ">=2.0.1",
+    "eslint-utils": ">=1.4.1"
   },
   "peerDependencies": {
     "react": "^16.8",

--- a/src/Dropdown/Dropdown.test.tsx.snap
+++ b/src/Dropdown/Dropdown.test.tsx.snap
@@ -123,8 +123,13 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
   padding-top: 10px !important;
 }
 
-.css-11,
-[data-css-11] {
+.css-8:-ms-clear,
+[data-css-8]:-ms-clear {
+  display: none;
+}
+
+.css-12,
+[data-css-12] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -135,8 +140,8 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
   -moz-transition: opacity .225s;
 }
 
-.css-12,
-[data-css-12] {
+.css-13,
+[data-css-13] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 10px;
@@ -145,22 +150,22 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
   color: #626262;
 }
 
-.css-13,
-[data-css-13] {
+.css-14,
+[data-css-14] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-14,
-[data-css-14] {
+.css-15,
+[data-css-15] {
   position: absolute;
   top: 0;
   right: 0;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   width: 10px;
   height: 10px;
   stroke: black;
@@ -217,7 +222,7 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
         >
           <div
             data-css-6=""
-            data-css-12=""
+            data-css-13=""
           >
             some label
              
@@ -225,7 +230,7 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
         </div>
         <div
           className="checkmark"
-          data-css-11=""
+          data-css-12=""
           data-css-6=""
         >
           <div
@@ -235,14 +240,14 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
               }
             }
             data-css-6=""
-            data-css-13=""
+            data-css-14=""
           />
         </div>
       </div>
       <div
         data-css-5=""
         data-css-7=""
-        data-css-14=""
+        data-css-15=""
         onClick={[Function]}
       >
         <div
@@ -251,7 +256,7 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
               "__html": "",
             }
           }
-          data-css-15=""
+          data-css-16=""
           data-css-6=""
           data-testid="dropdown-clear-icon"
         />
@@ -388,8 +393,13 @@ exports[`Dropdown should render with placement top 1`] = `
   padding-top: 10px !important;
 }
 
-.css-11,
-[data-css-11] {
+.css-8:-ms-clear,
+[data-css-8]:-ms-clear {
+  display: none;
+}
+
+.css-12,
+[data-css-12] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -400,8 +410,8 @@ exports[`Dropdown should render with placement top 1`] = `
   -moz-transition: opacity .225s;
 }
 
-.css-12,
-[data-css-12] {
+.css-13,
+[data-css-13] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 10px;
@@ -410,22 +420,22 @@ exports[`Dropdown should render with placement top 1`] = `
   color: #626262;
 }
 
-.css-13,
-[data-css-13] {
+.css-14,
+[data-css-14] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-14,
-[data-css-14] {
+.css-15,
+[data-css-15] {
   position: absolute;
   top: 0;
   right: 0;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   width: 10px;
   height: 10px;
   stroke: black;
@@ -482,7 +492,7 @@ exports[`Dropdown should render with placement top 1`] = `
         >
           <div
             data-css-6=""
-            data-css-12=""
+            data-css-13=""
           >
             some label
              
@@ -490,7 +500,7 @@ exports[`Dropdown should render with placement top 1`] = `
         </div>
         <div
           className="checkmark"
-          data-css-11=""
+          data-css-12=""
           data-css-6=""
         >
           <div
@@ -500,14 +510,14 @@ exports[`Dropdown should render with placement top 1`] = `
               }
             }
             data-css-6=""
-            data-css-13=""
+            data-css-14=""
           />
         </div>
       </div>
       <div
         data-css-5=""
         data-css-7=""
-        data-css-14=""
+        data-css-15=""
         onClick={[Function]}
       >
         <div
@@ -516,7 +526,7 @@ exports[`Dropdown should render with placement top 1`] = `
               "__html": "",
             }
           }
-          data-css-15=""
+          data-css-16=""
           data-css-6=""
           data-testid="dropdown-clear-icon"
         />

--- a/src/Dropdown/Dropdown.test.tsx.snap
+++ b/src/Dropdown/Dropdown.test.tsx.snap
@@ -123,8 +123,8 @@ exports[`Dropdown should render with placement bottom (default) 1`] = `
   padding-top: 10px !important;
 }
 
-.css-8:-ms-clear,
-[data-css-8]:-ms-clear {
+.css-8::-ms-clear,
+[data-css-8]::-ms-clear {
   display: none;
 }
 
@@ -393,8 +393,8 @@ exports[`Dropdown should render with placement top 1`] = `
   padding-top: 10px !important;
 }
 
-.css-8:-ms-clear,
-[data-css-8]:-ms-clear {
+.css-8::-ms-clear,
+[data-css-8]::-ms-clear {
   display: none;
 }
 

--- a/src/Input/Input.test.tsx.snap
+++ b/src/Input/Input.test.tsx.snap
@@ -55,8 +55,8 @@ exports[`Input component should render with all props 1`] = `
   padding-top: 10px !important;
 }
 
-.css-2:-ms-clear,
-[data-css-2]:-ms-clear {
+.css-2::-ms-clear,
+[data-css-2]::-ms-clear {
   display: none;
 }
 
@@ -322,8 +322,8 @@ exports[`Input component should render with required props only 1`] = `
   padding-top: 10px !important;
 }
 
-.css-4:-ms-clear,
-[data-css-4]:-ms-clear {
+.css-4::-ms-clear,
+[data-css-4]::-ms-clear {
   display: none;
 }
 

--- a/src/Input/Input.test.tsx.snap
+++ b/src/Input/Input.test.tsx.snap
@@ -55,8 +55,13 @@ exports[`Input component should render with all props 1`] = `
   padding-top: 10px !important;
 }
 
-.css-5,
-[data-css-5] {
+.css-2:-ms-clear,
+[data-css-2]:-ms-clear {
+  display: none;
+}
+
+.css-6,
+[data-css-6] {
   position: absolute;
   left: 40px;
   font-size: 10px;
@@ -66,8 +71,8 @@ exports[`Input component should render with all props 1`] = `
   -moz-transition: all .225s ease-out;
 }
 
-.css-6,
-[data-css-6] {
+.css-7,
+[data-css-7] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -78,28 +83,28 @@ exports[`Input component should render with all props 1`] = `
   -moz-transition: opacity .225s;
 }
 
-.css-7,
-[data-css-7] {
+.css-8,
+[data-css-8] {
   position: relative;
 }
 
-.css-8,
-[data-css-8] {
+.css-9,
+[data-css-9] {
   box-sizing: border-box;
   flex: 0 0 auto;
   -webkit-flex: 0 0 auto;
 }
 
-.css-9,
-[data-css-9] {
+.css-10,
+[data-css-10] {
   position: absolute;
   top: 0;
   left: 15px;
   bottom: 0;
 }
 
-.css-10,
-[data-css-10] {
+.css-11,
+[data-css-11] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -122,15 +127,15 @@ exports[`Input component should render with all props 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-11,
-[data-css-11] {
+.css-12,
+[data-css-12] {
   width: 16px;
   height: 16px;
   stroke: #626262;
 }
 
-.css-12,
-[data-css-12] {
+.css-13,
+[data-css-13] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 10px;
@@ -139,15 +144,15 @@ exports[`Input component should render with all props 1`] = `
   color: #626262;
 }
 
-.css-13,
-[data-css-13] {
+.css-14,
+[data-css-14] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-14,
-[data-css-14] {
+.css-15,
+[data-css-15] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 12px;
@@ -157,8 +162,8 @@ exports[`Input component should render with all props 1`] = `
 }
 
 <div
-  data-css-7=""
   data-css-8=""
+  data-css-9=""
   style={
     Object {
       "width": "100%",
@@ -167,8 +172,8 @@ exports[`Input component should render with all props 1`] = `
 >
   <div
     data-css-1=""
+    data-css-11=""
     data-css-10=""
-    data-css-9=""
   >
     <div
       dangerouslySetInnerHTML={
@@ -176,8 +181,8 @@ exports[`Input component should render with all props 1`] = `
           "__html": "",
         }
       }
-      data-css-8=""
-      data-css-11=""
+      data-css-9=""
+      data-css-12=""
     />
   </div>
   <input
@@ -195,8 +200,8 @@ exports[`Input component should render with all props 1`] = `
   />
   <div
     className="label"
-    data-css-5=""
-    data-css-8=""
+    data-css-6=""
+    data-css-9=""
     style={
       Object {
         "opacity": 1,
@@ -205,8 +210,8 @@ exports[`Input component should render with all props 1`] = `
     }
   >
     <div
-      data-css-8=""
-      data-css-12=""
+      data-css-9=""
+      data-css-13=""
     >
       label
        
@@ -215,8 +220,8 @@ exports[`Input component should render with all props 1`] = `
   </div>
   <div
     className="checkmark"
-    data-css-6=""
-    data-css-8=""
+    data-css-7=""
+    data-css-9=""
   >
     <div
       dangerouslySetInnerHTML={
@@ -224,17 +229,17 @@ exports[`Input component should render with all props 1`] = `
           "__html": "",
         }
       }
-      data-css-8=""
-      data-css-13=""
+      data-css-9=""
+      data-css-14=""
     />
   </div>
   <div
-    data-css-8=""
+    data-css-9=""
     data-css-0=""
   >
     <div
-      data-css-14=""
-      data-css-8=""
+      data-css-15=""
+      data-css-9=""
     >
       5
       /
@@ -315,6 +320,11 @@ exports[`Input component should render with required props only 1`] = `
 .css-4:-webkit-autofill,
 [data-css-4]:-webkit-autofill {
   padding-top: 10px !important;
+}
+
+.css-4:-ms-clear,
+[data-css-4]:-ms-clear {
+  display: none;
 }
 
 <div

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -42,9 +42,6 @@ const styles = {
       '&:-webkit-autofill': {
         paddingTop: '10px !important',
       },
-      '::-ms-clear': {
-        display: 'none',
-      },
     }),
   area: (lines: number, showLabel: boolean) =>
     css(createTextStyles({ size: 'm' }), {

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -42,6 +42,9 @@ const styles = {
       '&:-webkit-autofill': {
         paddingTop: '10px !important',
       },
+      ':-ms-clear': {
+        display: 'none',
+      },
     }),
   area: (lines: number, showLabel: boolean) =>
     css(createTextStyles({ size: 'm' }), {

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -42,6 +42,9 @@ const styles = {
       '&:-webkit-autofill': {
         paddingTop: '10px !important',
       },
+      '::-ms-clear': {
+        display: 'none',
+      },
     }),
   area: (lines: number, showLabel: boolean) =>
     css(createTextStyles({ size: 'm' }), {

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -42,7 +42,7 @@ const styles = {
       '&:-webkit-autofill': {
         paddingTop: '10px !important',
       },
-      ':-ms-clear': {
+      '::-ms-clear': {
         display: 'none',
       },
     }),

--- a/src/SearchableDropdown/SearchableDropdown.test.tsx.snap
+++ b/src/SearchableDropdown/SearchableDropdown.test.tsx.snap
@@ -259,16 +259,21 @@ exports[`SearchableDropdown should render with icon 1`] = `
   padding-top: 10px !important;
 }
 
-.css-27,
-[data-css-27] {
+.css-24:-ms-clear,
+[data-css-24]:-ms-clear {
+  display: none;
+}
+
+.css-28,
+[data-css-28] {
   position: absolute;
   top: 0;
   left: 15px;
   bottom: 0;
 }
 
-.css-28,
-[data-css-28] {
+.css-29,
+[data-css-29] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -291,15 +296,15 @@ exports[`SearchableDropdown should render with icon 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-29,
-[data-css-29] {
+.css-30,
+[data-css-30] {
   width: 16px;
   height: 16px;
   stroke: #626262;
 }
 
-.css-30,
-[data-css-30] {
+.css-31,
+[data-css-31] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
@@ -307,8 +312,8 @@ exports[`SearchableDropdown should render with icon 1`] = `
   background-color: white;
 }
 
-.css-31,
-[data-css-31] {
+.css-32,
+[data-css-32] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -332,8 +337,8 @@ exports[`SearchableDropdown should render with icon 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-32,
-[data-css-32] {
+.css-33,
+[data-css-33] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;
@@ -342,8 +347,8 @@ exports[`SearchableDropdown should render with icon 1`] = `
   color: #333333;
 }
 
-.css-33,
-[data-css-33] {
+.css-34,
+[data-css-34] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -362,30 +367,35 @@ exports[`SearchableDropdown should render with icon 1`] = `
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-33:required,
-[data-css-33]:required {
+.css-34:required,
+[data-css-34]:required {
   box-shadow: none;
 }
 
-.css-33:-webkit-autofill ~ .label,
-[data-css-33]:-webkit-autofill ~ .label {
+.css-34:-webkit-autofill ~ .label,
+[data-css-34]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-33:-webkit-autofill ~ .checkmark,
-[data-css-33]:-webkit-autofill ~ .checkmark {
+.css-34:-webkit-autofill ~ .checkmark,
+[data-css-34]:-webkit-autofill ~ .checkmark {
   opacity: 1 !important;
   top: 8px;
 }
 
-.css-33:-webkit-autofill,
-[data-css-33]:-webkit-autofill {
+.css-34:-webkit-autofill,
+[data-css-34]:-webkit-autofill {
   padding-top: 10px !important;
 }
 
-.css-36,
-[data-css-36] {
+.css-34:-ms-clear,
+[data-css-34]:-ms-clear {
+  display: none;
+}
+
+.css-38,
+[data-css-38] {
   position: absolute;
   left: 40px;
   font-size: 10px;
@@ -420,17 +430,17 @@ exports[`SearchableDropdown should render with icon 1`] = `
         >
           <div
             data-css-23=""
+            data-css-29=""
             data-css-28=""
-            data-css-27=""
           >
             <div
               data-css-8=""
-              data-css-29=""
+              data-css-30=""
             />
           </div>
           <input
             aria-required="false"
-            data-css-33=""
+            data-css-34=""
             data-css-0=""
             disabled=""
             name=""
@@ -441,7 +451,7 @@ exports[`SearchableDropdown should render with icon 1`] = `
           />
           <div
             class="label"
-            data-css-36=""
+            data-css-38=""
             data-css-8=""
             style="opacity: 1; top: 8px;"
           >
@@ -504,12 +514,12 @@ exports[`SearchableDropdown should render with icon 1`] = `
             >
               <div
                 data-css-23=""
+                data-css-29=""
                 data-css-28=""
-                data-css-27=""
               >
                 <div
                   data-css-8=""
-                  data-css-29=""
+                  data-css-30=""
                 />
               </div>
               <input
@@ -541,14 +551,14 @@ exports[`SearchableDropdown should render with icon 1`] = `
             >
               <div
                 aria-selected="false"
-                data-css-30=""
-                data-css-4=""
                 data-css-31=""
+                data-css-4=""
+                data-css-32=""
                 id="downshift-2-item-0"
                 role="option"
               >
                 <div
-                  data-css-32=""
+                  data-css-33=""
                   data-css-8=""
                   data-css-2=""
                 >
@@ -557,14 +567,14 @@ exports[`SearchableDropdown should render with icon 1`] = `
               </div>
               <div
                 aria-selected="false"
-                data-css-30=""
-                data-css-4=""
                 data-css-31=""
+                data-css-4=""
+                data-css-32=""
                 id="downshift-2-item-1"
                 role="option"
               >
                 <div
-                  data-css-32=""
+                  data-css-33=""
                   data-css-8=""
                   data-css-2=""
                 >
@@ -573,14 +583,14 @@ exports[`SearchableDropdown should render with icon 1`] = `
               </div>
               <div
                 aria-selected="false"
-                data-css-30=""
-                data-css-4=""
                 data-css-31=""
+                data-css-4=""
+                data-css-32=""
                 id="downshift-2-item-2"
                 role="option"
               >
                 <div
-                  data-css-32=""
+                  data-css-33=""
                   data-css-8=""
                   data-css-2=""
                 >
@@ -867,16 +877,21 @@ exports[`SearchableDropdown should render with load more 1`] = `
   padding-top: 10px !important;
 }
 
-.css-28,
-[data-css-28] {
+.css-25:-ms-clear,
+[data-css-25]:-ms-clear {
+  display: none;
+}
+
+.css-29,
+[data-css-29] {
   position: absolute;
   top: 0;
   left: 15px;
   bottom: 0;
 }
 
-.css-29,
-[data-css-29] {
+.css-30,
+[data-css-30] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -899,15 +914,15 @@ exports[`SearchableDropdown should render with load more 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-30,
-[data-css-30] {
+.css-31,
+[data-css-31] {
   width: 16px;
   height: 16px;
   stroke: #626262;
 }
 
-.css-31,
-[data-css-31] {
+.css-32,
+[data-css-32] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
@@ -915,8 +930,8 @@ exports[`SearchableDropdown should render with load more 1`] = `
   background-color: white;
 }
 
-.css-32,
-[data-css-32] {
+.css-33,
+[data-css-33] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -940,8 +955,8 @@ exports[`SearchableDropdown should render with load more 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-33,
-[data-css-33] {
+.css-34,
+[data-css-34] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;
@@ -950,8 +965,8 @@ exports[`SearchableDropdown should render with load more 1`] = `
   color: #333333;
 }
 
-.css-34,
-[data-css-34] {
+.css-35,
+[data-css-35] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -969,38 +984,43 @@ exports[`SearchableDropdown should render with load more 1`] = `
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-34:required,
-[data-css-34]:required {
+.css-35:required,
+[data-css-35]:required {
   box-shadow: none;
 }
 
-.css-34:-webkit-autofill ~ .label,
-[data-css-34]:-webkit-autofill ~ .label {
+.css-35:-webkit-autofill ~ .label,
+[data-css-35]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-34:-webkit-autofill ~ .checkmark,
-[data-css-34]:-webkit-autofill ~ .checkmark {
+.css-35:-webkit-autofill ~ .checkmark,
+[data-css-35]:-webkit-autofill ~ .checkmark {
   opacity: 1 !important;
   top: 8px;
 }
 
-.css-34:-webkit-autofill,
-[data-css-34]:-webkit-autofill {
+.css-35:-webkit-autofill,
+[data-css-35]:-webkit-autofill {
   padding-top: 10px !important;
 }
 
-.css-37,
-[data-css-37] {
+.css-35:-ms-clear,
+[data-css-35]:-ms-clear {
+  display: none;
+}
+
+.css-39,
+[data-css-39] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
   background-color: white;
 }
 
-.css-38,
-[data-css-38] {
+.css-40,
+[data-css-40] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-weight: 600;
@@ -1035,7 +1055,7 @@ exports[`SearchableDropdown should render with load more 1`] = `
         >
           <input
             aria-required="false"
-            data-css-34=""
+            data-css-35=""
             data-css-1=""
             disabled=""
             name=""
@@ -1109,12 +1129,12 @@ exports[`SearchableDropdown should render with load more 1`] = `
             >
               <div
                 data-css-24=""
+                data-css-30=""
                 data-css-29=""
-                data-css-28=""
               >
                 <div
                   data-css-9=""
-                  data-css-30=""
+                  data-css-31=""
                 />
               </div>
               <input
@@ -1146,14 +1166,14 @@ exports[`SearchableDropdown should render with load more 1`] = `
             >
               <div
                 aria-selected="false"
-                data-css-31=""
-                data-css-5=""
                 data-css-32=""
+                data-css-5=""
+                data-css-33=""
                 id="downshift-4-item-0"
                 role="option"
               >
                 <div
-                  data-css-33=""
+                  data-css-34=""
                   data-css-9=""
                   data-css-3=""
                 >
@@ -1162,14 +1182,14 @@ exports[`SearchableDropdown should render with load more 1`] = `
               </div>
               <div
                 aria-selected="false"
-                data-css-31=""
-                data-css-5=""
                 data-css-32=""
+                data-css-5=""
+                data-css-33=""
                 id="downshift-4-item-1"
                 role="option"
               >
                 <div
-                  data-css-33=""
+                  data-css-34=""
                   data-css-9=""
                   data-css-3=""
                 >
@@ -1178,14 +1198,14 @@ exports[`SearchableDropdown should render with load more 1`] = `
               </div>
               <div
                 aria-selected="false"
-                data-css-31=""
-                data-css-5=""
                 data-css-32=""
+                data-css-5=""
+                data-css-33=""
                 id="downshift-4-item-2"
                 role="option"
               >
                 <div
-                  data-css-33=""
+                  data-css-34=""
                   data-css-9=""
                   data-css-3=""
                 >
@@ -1193,14 +1213,14 @@ exports[`SearchableDropdown should render with load more 1`] = `
                 </div>
               </div>
               <div
-                data-css-37=""
+                data-css-39=""
                 data-css-5=""
-                data-css-29=""
+                data-css-30=""
               >
                 <div
                   data-css-9=""
                   data-css-3=""
-                  data-css-38=""
+                  data-css-40=""
                   data-testid="searchable-dropdown-load-more"
                 >
                   Load more
@@ -1480,16 +1500,21 @@ exports[`SearchableDropdown should render with no results 1`] = `
   padding-top: 10px !important;
 }
 
-.css-26,
-[data-css-26] {
+.css-23:-ms-clear,
+[data-css-23]:-ms-clear {
+  display: none;
+}
+
+.css-27,
+[data-css-27] {
   position: absolute;
   top: 0;
   left: 15px;
   bottom: 0;
 }
 
-.css-27,
-[data-css-27] {
+.css-28,
+[data-css-28] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -1512,15 +1537,15 @@ exports[`SearchableDropdown should render with no results 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-28,
-[data-css-28] {
+.css-29,
+[data-css-29] {
   width: 16px;
   height: 16px;
   stroke: #626262;
 }
 
-.css-29,
-[data-css-29] {
+.css-30,
+[data-css-30] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;
@@ -1529,8 +1554,8 @@ exports[`SearchableDropdown should render with no results 1`] = `
   color: #333333;
 }
 
-.css-30,
-[data-css-30] {
+.css-31,
+[data-css-31] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -1548,30 +1573,35 @@ exports[`SearchableDropdown should render with no results 1`] = `
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-30:required,
-[data-css-30]:required {
+.css-31:required,
+[data-css-31]:required {
   box-shadow: none;
 }
 
-.css-30:-webkit-autofill ~ .label,
-[data-css-30]:-webkit-autofill ~ .label {
+.css-31:-webkit-autofill ~ .label,
+[data-css-31]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-30:-webkit-autofill ~ .checkmark,
-[data-css-30]:-webkit-autofill ~ .checkmark {
+.css-31:-webkit-autofill ~ .checkmark,
+[data-css-31]:-webkit-autofill ~ .checkmark {
   opacity: 1 !important;
   top: 8px;
 }
 
-.css-30:-webkit-autofill,
-[data-css-30]:-webkit-autofill {
+.css-31:-webkit-autofill,
+[data-css-31]:-webkit-autofill {
   padding-top: 10px !important;
 }
 
-.css-33,
-[data-css-33] {
+.css-31:-ms-clear,
+[data-css-31]:-ms-clear {
+  display: none;
+}
+
+.css-35,
+[data-css-35] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
@@ -1603,7 +1633,7 @@ exports[`SearchableDropdown should render with no results 1`] = `
         >
           <input
             aria-required="false"
-            data-css-30=""
+            data-css-31=""
             data-css-1=""
             disabled=""
             name=""
@@ -1677,12 +1707,12 @@ exports[`SearchableDropdown should render with no results 1`] = `
             >
               <div
                 data-css-22=""
+                data-css-28=""
                 data-css-27=""
-                data-css-26=""
               >
                 <div
                   data-css-7=""
-                  data-css-28=""
+                  data-css-29=""
                 />
               </div>
               <input
@@ -1713,11 +1743,11 @@ exports[`SearchableDropdown should render with no results 1`] = `
               data-css-21=""
             >
               <div
-                data-css-33=""
-                data-css-27=""
+                data-css-35=""
+                data-css-28=""
               >
                 <div
-                  data-css-29=""
+                  data-css-30=""
                   data-css-7=""
                   data-css-3=""
                   data-testid="searchable-dropdown-no-results"
@@ -1850,8 +1880,13 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   padding-top: 10px !important;
 }
 
-.css-14,
-[data-css-14] {
+.css-11:-ms-clear,
+[data-css-11]:-ms-clear {
+  display: none;
+}
+
+.css-15,
+[data-css-15] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -1862,8 +1897,8 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   -moz-transition: opacity .225s;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 10px;
@@ -1872,22 +1907,22 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   color: #626262;
 }
 
-.css-16,
-[data-css-16] {
+.css-17,
+[data-css-17] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-17,
-[data-css-17] {
+.css-18,
+[data-css-18] {
   position: absolute;
   top: 0;
   right: 0;
 }
 
-.css-18,
-[data-css-18] {
+.css-19,
+[data-css-19] {
   box-sizing: border-box;
   align-content: stretch;
   align-items: stretch;
@@ -1910,15 +1945,15 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   -webkit-flex: 0 0 auto;
 }
 
-.css-19,
-[data-css-19] {
+.css-20,
+[data-css-20] {
   width: 10px;
   height: 10px;
   stroke: black;
 }
 
-.css-20,
-[data-css-20] {
+.css-21,
+[data-css-21] {
   align-items: stretch;
   border: none;
   box-shadow: 1px 1px 3px rgba(29, 29, 29, 0.125);
@@ -1938,8 +1973,8 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   -webkit-flex-direction: column;
 }
 
-.css-21,
-[data-css-21] {
+.css-22,
+[data-css-22] {
   box-shadow: 1px 1px 3px rgba(29, 29, 29, 0.125);
   background-color: #ffffff;
   max-height: 200px;
@@ -1948,35 +1983,35 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   z-index: 9999;
 }
 
-.css-22,
-[data-css-22] {
+.css-23,
+[data-css-23] {
   border-top: 1px solid #ecf0f1;
   max-height: 151px;
   overflow-y: auto;
   overflow-x: hidden;
 }
 
-.css-22::-webkit-scrollbar,
-[data-css-22]::-webkit-scrollbar {
+.css-23::-webkit-scrollbar,
+[data-css-23]::-webkit-scrollbar {
   -webkit-appearance: none;
   width: 10px;
 }
 
-.css-22::-webkit-scrollbar-thumb,
-[data-css-22]::-webkit-scrollbar-thumb {
+.css-23::-webkit-scrollbar-thumb,
+[data-css-23]::-webkit-scrollbar-thumb {
   border-radius: 6px;
   border: 2px solid white;
   background-color: rgba(0,0,0,.3);
   box-shadow: 0 0 1px rgba(255,255,255,.5);
 }
 
-.css-25,
-[data-css-25] {
+.css-26,
+[data-css-26] {
   position: absolute;
 }
 
-.css-26,
-[data-css-26] {
+.css-27,
+[data-css-27] {
   box-sizing: border-box;
   align-content: stretch;
   align-items: stretch;
@@ -1999,13 +2034,13 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   -webkit-flex: 0 0 auto;
 }
 
-.css-27,
-[data-css-27] {
+.css-28,
+[data-css-28] {
   pointer-events: none;
 }
 
-.css-28,
-[data-css-28] {
+.css-29,
+[data-css-29] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -2024,38 +2059,43 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-28:required,
-[data-css-28]:required {
+.css-29:required,
+[data-css-29]:required {
   box-shadow: none;
 }
 
-.css-28:-webkit-autofill ~ .label,
-[data-css-28]:-webkit-autofill ~ .label {
+.css-29:-webkit-autofill ~ .label,
+[data-css-29]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-28:-webkit-autofill ~ .checkmark,
-[data-css-28]:-webkit-autofill ~ .checkmark {
+.css-29:-webkit-autofill ~ .checkmark,
+[data-css-29]:-webkit-autofill ~ .checkmark {
   opacity: 1 !important;
   top: 8px;
 }
 
-.css-28:-webkit-autofill,
-[data-css-28]:-webkit-autofill {
+.css-29:-webkit-autofill,
+[data-css-29]:-webkit-autofill {
   padding-top: 10px !important;
 }
 
-.css-31,
-[data-css-31] {
+.css-29:-ms-clear,
+[data-css-29]:-ms-clear {
+  display: none;
+}
+
+.css-33,
+[data-css-33] {
   position: absolute;
   top: 0;
   left: 15px;
   bottom: 0;
 }
 
-.css-32,
-[data-css-32] {
+.css-34,
+[data-css-34] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -2078,15 +2118,15 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   -webkit-flex: 0 0 auto;
 }
 
-.css-33,
-[data-css-33] {
+.css-35,
+[data-css-35] {
   width: 16px;
   height: 16px;
   stroke: #626262;
 }
 
-.css-34,
-[data-css-34] {
+.css-36,
+[data-css-36] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
@@ -2094,8 +2134,8 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   background-color: white;
 }
 
-.css-35,
-[data-css-35] {
+.css-37,
+[data-css-37] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -2119,8 +2159,8 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   -webkit-flex: 0 0 auto;
 }
 
-.css-36,
-[data-css-36] {
+.css-38,
+[data-css-38] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;
@@ -2135,7 +2175,7 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
     aria-haspopup="listbox"
     aria-labelledby="downshift-0-label"
     aria-owns="downshift-0-menu"
-    data-css-20=""
+    data-css-21=""
     role="combobox"
   >
     <div
@@ -2171,7 +2211,7 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
           >
             <div
               data-css-9=""
-              data-css-15=""
+              data-css-16=""
             >
               some label
                
@@ -2179,25 +2219,25 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
           </div>
           <div
             class="checkmark"
-            data-css-14=""
+            data-css-15=""
             data-css-9=""
           >
             <div
               data-css-9=""
-              data-css-16=""
+              data-css-17=""
             />
           </div>
         </div>
         <div
-          data-css-17=""
+          data-css-18=""
           data-css-9=""
           data-css-8=""
         >
           <div
-            data-css-18=""
+            data-css-19=""
           >
             <div
-              data-css-19=""
+              data-css-20=""
               data-css-9=""
               data-testid="searchable-dropdown-arrow-down"
             />
@@ -2210,12 +2250,12 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
       data-css-9=""
     >
       <div
-        data-css-25=""
-        data-css-21=""
+        data-css-26=""
+        data-css-22=""
         data-css-9=""
       >
         <div
-          data-css-26=""
+          data-css-27=""
         >
           <div
             data-css-9=""
@@ -2227,18 +2267,18 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
               style="width: 100%;"
             >
               <div
-                data-css-27=""
-                data-css-32=""
-                data-css-31=""
+                data-css-28=""
+                data-css-34=""
+                data-css-33=""
               >
                 <div
                   data-css-9=""
-                  data-css-33=""
+                  data-css-35=""
                 />
               </div>
               <input
                 aria-required="false"
-                data-css-28=""
+                data-css-29=""
                 data-e2e="searchable-dropdown-search-input"
                 placeholder="Search"
                 type="text"
@@ -2246,33 +2286,33 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
               />
               <div
                 class="checkmark"
-                data-css-14=""
+                data-css-15=""
                 data-css-9=""
               >
                 <div
                   data-css-9=""
-                  data-css-16=""
+                  data-css-17=""
                 />
               </div>
             </div>
           </div>
           <div
-            data-css-22=""
+            data-css-23=""
             data-css-9=""
           >
             <div
-              data-css-26=""
+              data-css-27=""
             >
               <div
                 aria-selected="false"
-                data-css-34=""
+                data-css-36=""
                 data-css-5=""
-                data-css-35=""
+                data-css-37=""
                 id="downshift-0-item-0"
                 role="option"
               >
                 <div
-                  data-css-36=""
+                  data-css-38=""
                   data-css-9=""
                   data-css-3=""
                 >
@@ -2281,14 +2321,14 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
               </div>
               <div
                 aria-selected="false"
-                data-css-34=""
+                data-css-36=""
                 data-css-5=""
-                data-css-35=""
+                data-css-37=""
                 id="downshift-0-item-1"
                 role="option"
               >
                 <div
-                  data-css-36=""
+                  data-css-38=""
                   data-css-9=""
                   data-css-3=""
                 >
@@ -2297,14 +2337,14 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
               </div>
               <div
                 aria-selected="false"
-                data-css-34=""
+                data-css-36=""
                 data-css-5=""
-                data-css-35=""
+                data-css-37=""
                 id="downshift-0-item-2"
                 role="option"
               >
                 <div
-                  data-css-36=""
+                  data-css-38=""
                   data-css-9=""
                   data-css-3=""
                 >
@@ -2436,8 +2476,13 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   padding-top: 10px !important;
 }
 
-.css-14,
-[data-css-14] {
+.css-11:-ms-clear,
+[data-css-11]:-ms-clear {
+  display: none;
+}
+
+.css-15,
+[data-css-15] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -2448,8 +2493,8 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   -moz-transition: opacity .225s;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 10px;
@@ -2458,22 +2503,22 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   color: #626262;
 }
 
-.css-16,
-[data-css-16] {
+.css-17,
+[data-css-17] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-17,
-[data-css-17] {
+.css-18,
+[data-css-18] {
   position: absolute;
   top: 0;
   right: 0;
 }
 
-.css-18,
-[data-css-18] {
+.css-19,
+[data-css-19] {
   box-sizing: border-box;
   align-content: stretch;
   align-items: stretch;
@@ -2496,15 +2541,15 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-19,
-[data-css-19] {
+.css-20,
+[data-css-20] {
   width: 10px;
   height: 10px;
   stroke: black;
 }
 
-.css-20,
-[data-css-20] {
+.css-21,
+[data-css-21] {
   align-items: stretch;
   border: none;
   box-shadow: 1px 1px 3px rgba(29, 29, 29, 0.125);
@@ -2524,8 +2569,8 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   -webkit-flex-direction: column;
 }
 
-.css-21,
-[data-css-21] {
+.css-22,
+[data-css-22] {
   box-shadow: 1px 1px 3px rgba(29, 29, 29, 0.125);
   background-color: #ffffff;
   max-height: 200px;
@@ -2534,30 +2579,30 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   z-index: 9999;
 }
 
-.css-22,
-[data-css-22] {
+.css-23,
+[data-css-23] {
   border-top: 1px solid #ecf0f1;
   max-height: 151px;
   overflow-y: auto;
   overflow-x: hidden;
 }
 
-.css-22::-webkit-scrollbar,
-[data-css-22]::-webkit-scrollbar {
+.css-23::-webkit-scrollbar,
+[data-css-23]::-webkit-scrollbar {
   -webkit-appearance: none;
   width: 10px;
 }
 
-.css-22::-webkit-scrollbar-thumb,
-[data-css-22]::-webkit-scrollbar-thumb {
+.css-23::-webkit-scrollbar-thumb,
+[data-css-23]::-webkit-scrollbar-thumb {
   border-radius: 6px;
   border: 2px solid white;
   background-color: rgba(0,0,0,.3);
   box-shadow: 0 0 1px rgba(255,255,255,.5);
 }
 
-.css-25,
-[data-css-25] {
+.css-26,
+[data-css-26] {
   box-sizing: border-box;
   align-content: stretch;
   align-items: stretch;
@@ -2580,13 +2625,13 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-26,
-[data-css-26] {
+.css-27,
+[data-css-27] {
   pointer-events: none;
 }
 
-.css-27,
-[data-css-27] {
+.css-28,
+[data-css-28] {
   display: inline;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -2605,38 +2650,43 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   -moz-transition: padding-top .225s ease-out;
 }
 
-.css-27:required,
-[data-css-27]:required {
+.css-28:required,
+[data-css-28]:required {
   box-shadow: none;
 }
 
-.css-27:-webkit-autofill ~ .label,
-[data-css-27]:-webkit-autofill ~ .label {
+.css-28:-webkit-autofill ~ .label,
+[data-css-28]:-webkit-autofill ~ .label {
   opacity: 1 !important;
   top: 8px !important;
 }
 
-.css-27:-webkit-autofill ~ .checkmark,
-[data-css-27]:-webkit-autofill ~ .checkmark {
+.css-28:-webkit-autofill ~ .checkmark,
+[data-css-28]:-webkit-autofill ~ .checkmark {
   opacity: 1 !important;
   top: 8px;
 }
 
-.css-27:-webkit-autofill,
-[data-css-27]:-webkit-autofill {
+.css-28:-webkit-autofill,
+[data-css-28]:-webkit-autofill {
   padding-top: 10px !important;
 }
 
-.css-30,
-[data-css-30] {
+.css-28:-ms-clear,
+[data-css-28]:-ms-clear {
+  display: none;
+}
+
+.css-32,
+[data-css-32] {
   position: absolute;
   top: 0;
   left: 15px;
   bottom: 0;
 }
 
-.css-31,
-[data-css-31] {
+.css-33,
+[data-css-33] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -2659,15 +2709,15 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-32,
-[data-css-32] {
+.css-34,
+[data-css-34] {
   width: 16px;
   height: 16px;
   stroke: #626262;
 }
 
-.css-33,
-[data-css-33] {
+.css-35,
+[data-css-35] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
@@ -2675,8 +2725,8 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   background-color: white;
 }
 
-.css-34,
-[data-css-34] {
+.css-36,
+[data-css-36] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -2700,8 +2750,8 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-35,
-[data-css-35] {
+.css-37,
+[data-css-37] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;
@@ -2710,14 +2760,14 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   color: #333333;
 }
 
-.css-36,
-[data-css-36] {
+.css-38,
+[data-css-38] {
   position: absolute;
   bottom: 50px;
 }
 
-.css-37,
-[data-css-37] {
+.css-39,
+[data-css-39] {
   box-sizing: border-box;
   align-content: stretch;
   align-items: stretch;
@@ -2746,7 +2796,7 @@ exports[`SearchableDropdown should render with placement top 1`] = `
     aria-haspopup="listbox"
     aria-labelledby="downshift-1-label"
     aria-owns="downshift-1-menu"
-    data-css-20=""
+    data-css-21=""
     role="combobox"
   >
     <div
@@ -2782,7 +2832,7 @@ exports[`SearchableDropdown should render with placement top 1`] = `
           >
             <div
               data-css-9=""
-              data-css-15=""
+              data-css-16=""
             >
               some label
                
@@ -2790,25 +2840,25 @@ exports[`SearchableDropdown should render with placement top 1`] = `
           </div>
           <div
             class="checkmark"
-            data-css-14=""
+            data-css-15=""
             data-css-9=""
           >
             <div
               data-css-9=""
-              data-css-16=""
+              data-css-17=""
             />
           </div>
         </div>
         <div
-          data-css-17=""
+          data-css-18=""
           data-css-9=""
           data-css-8=""
         >
           <div
-            data-css-18=""
+            data-css-19=""
           >
             <div
-              data-css-19=""
+              data-css-20=""
               data-css-9=""
               data-testid="searchable-dropdown-arrow-up"
             />
@@ -2821,12 +2871,12 @@ exports[`SearchableDropdown should render with placement top 1`] = `
       data-css-9=""
     >
       <div
-        data-css-36=""
-        data-css-21=""
+        data-css-38=""
+        data-css-22=""
         data-css-9=""
       >
         <div
-          data-css-37=""
+          data-css-39=""
         >
           <div
             data-css-9=""
@@ -2838,18 +2888,18 @@ exports[`SearchableDropdown should render with placement top 1`] = `
               style="width: 100%;"
             >
               <div
-                data-css-26=""
-                data-css-31=""
-                data-css-30=""
+                data-css-27=""
+                data-css-33=""
+                data-css-32=""
               >
                 <div
                   data-css-9=""
-                  data-css-32=""
+                  data-css-34=""
                 />
               </div>
               <input
                 aria-required="false"
-                data-css-27=""
+                data-css-28=""
                 data-e2e="searchable-dropdown-search-input"
                 placeholder="Search"
                 type="text"
@@ -2857,33 +2907,33 @@ exports[`SearchableDropdown should render with placement top 1`] = `
               />
               <div
                 class="checkmark"
-                data-css-14=""
+                data-css-15=""
                 data-css-9=""
               >
                 <div
                   data-css-9=""
-                  data-css-16=""
+                  data-css-17=""
                 />
               </div>
             </div>
           </div>
           <div
-            data-css-22=""
+            data-css-23=""
             data-css-9=""
           >
             <div
-              data-css-25=""
+              data-css-26=""
             >
               <div
                 aria-selected="false"
-                data-css-33=""
+                data-css-35=""
                 data-css-5=""
-                data-css-34=""
+                data-css-36=""
                 id="downshift-1-item-0"
                 role="option"
               >
                 <div
-                  data-css-35=""
+                  data-css-37=""
                   data-css-9=""
                   data-css-3=""
                 >
@@ -2892,14 +2942,14 @@ exports[`SearchableDropdown should render with placement top 1`] = `
               </div>
               <div
                 aria-selected="false"
-                data-css-33=""
+                data-css-35=""
                 data-css-5=""
-                data-css-34=""
+                data-css-36=""
                 id="downshift-1-item-1"
                 role="option"
               >
                 <div
-                  data-css-35=""
+                  data-css-37=""
                   data-css-9=""
                   data-css-3=""
                 >
@@ -2908,14 +2958,14 @@ exports[`SearchableDropdown should render with placement top 1`] = `
               </div>
               <div
                 aria-selected="false"
-                data-css-33=""
+                data-css-35=""
                 data-css-5=""
-                data-css-34=""
+                data-css-36=""
                 id="downshift-1-item-2"
                 role="option"
               >
                 <div
-                  data-css-35=""
+                  data-css-37=""
                   data-css-9=""
                   data-css-3=""
                 >

--- a/src/SearchableDropdown/SearchableDropdown.test.tsx.snap
+++ b/src/SearchableDropdown/SearchableDropdown.test.tsx.snap
@@ -259,8 +259,8 @@ exports[`SearchableDropdown should render with icon 1`] = `
   padding-top: 10px !important;
 }
 
-.css-24:-ms-clear,
-[data-css-24]:-ms-clear {
+.css-24::-ms-clear,
+[data-css-24]::-ms-clear {
   display: none;
 }
 
@@ -389,8 +389,8 @@ exports[`SearchableDropdown should render with icon 1`] = `
   padding-top: 10px !important;
 }
 
-.css-34:-ms-clear,
-[data-css-34]:-ms-clear {
+.css-34::-ms-clear,
+[data-css-34]::-ms-clear {
   display: none;
 }
 
@@ -877,8 +877,8 @@ exports[`SearchableDropdown should render with load more 1`] = `
   padding-top: 10px !important;
 }
 
-.css-25:-ms-clear,
-[data-css-25]:-ms-clear {
+.css-25::-ms-clear,
+[data-css-25]::-ms-clear {
   display: none;
 }
 
@@ -1006,8 +1006,8 @@ exports[`SearchableDropdown should render with load more 1`] = `
   padding-top: 10px !important;
 }
 
-.css-35:-ms-clear,
-[data-css-35]:-ms-clear {
+.css-35::-ms-clear,
+[data-css-35]::-ms-clear {
   display: none;
 }
 
@@ -1500,8 +1500,8 @@ exports[`SearchableDropdown should render with no results 1`] = `
   padding-top: 10px !important;
 }
 
-.css-23:-ms-clear,
-[data-css-23]:-ms-clear {
+.css-23::-ms-clear,
+[data-css-23]::-ms-clear {
   display: none;
 }
 
@@ -1595,8 +1595,8 @@ exports[`SearchableDropdown should render with no results 1`] = `
   padding-top: 10px !important;
 }
 
-.css-31:-ms-clear,
-[data-css-31]:-ms-clear {
+.css-31::-ms-clear,
+[data-css-31]::-ms-clear {
   display: none;
 }
 
@@ -1880,8 +1880,8 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   padding-top: 10px !important;
 }
 
-.css-11:-ms-clear,
-[data-css-11]:-ms-clear {
+.css-11::-ms-clear,
+[data-css-11]::-ms-clear {
   display: none;
 }
 
@@ -2081,8 +2081,8 @@ exports[`SearchableDropdown should render with placement bottom (default) 1`] = 
   padding-top: 10px !important;
 }
 
-.css-29:-ms-clear,
-[data-css-29]:-ms-clear {
+.css-29::-ms-clear,
+[data-css-29]::-ms-clear {
   display: none;
 }
 
@@ -2476,8 +2476,8 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   padding-top: 10px !important;
 }
 
-.css-11:-ms-clear,
-[data-css-11]:-ms-clear {
+.css-11::-ms-clear,
+[data-css-11]::-ms-clear {
   display: none;
 }
 
@@ -2672,8 +2672,8 @@ exports[`SearchableDropdown should render with placement top 1`] = `
   padding-top: 10px !important;
 }
 
-.css-28:-ms-clear,
-[data-css-28]:-ms-clear {
+.css-28::-ms-clear,
+[data-css-28]::-ms-clear {
   display: none;
 }
 

--- a/src/TextInput/TextInput.test.tsx.snap
+++ b/src/TextInput/TextInput.test.tsx.snap
@@ -73,8 +73,13 @@ exports[`TextInput renders 1`] = `
   padding-top: 10px !important;
 }
 
-.css-5,
-[data-css-5] {
+.css-2:-ms-clear,
+[data-css-2]:-ms-clear {
+  display: none;
+}
+
+.css-6,
+[data-css-6] {
   position: absolute;
   left: 15px;
   font-size: 10px;
@@ -84,8 +89,8 @@ exports[`TextInput renders 1`] = `
   -moz-transition: all .225s ease-out;
 }
 
-.css-6,
-[data-css-6] {
+.css-7,
+[data-css-7] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -96,20 +101,20 @@ exports[`TextInput renders 1`] = `
   -moz-transition: opacity .225s;
 }
 
-.css-7,
-[data-css-7] {
+.css-8,
+[data-css-8] {
   position: relative;
 }
 
-.css-8,
-[data-css-8] {
+.css-9,
+[data-css-9] {
   box-sizing: border-box;
   flex: 0 0 auto;
   -webkit-flex: 0 0 auto;
 }
 
-.css-9,
-[data-css-9] {
+.css-10,
+[data-css-10] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 10px;
@@ -118,8 +123,8 @@ exports[`TextInput renders 1`] = `
   color: #626262;
 }
 
-.css-10,
-[data-css-10] {
+.css-11,
+[data-css-11] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
@@ -130,8 +135,8 @@ exports[`TextInput renders 1`] = `
   data-css-1=""
 >
   <div
-    data-css-7=""
     data-css-8=""
+    data-css-9=""
     style={
       Object {
         "width": "100%",
@@ -149,8 +154,8 @@ exports[`TextInput renders 1`] = `
     />
     <div
       className="label"
-      data-css-8=""
-      data-css-5=""
+      data-css-9=""
+      data-css-6=""
       style={
         Object {
           "opacity": 0,
@@ -159,8 +164,8 @@ exports[`TextInput renders 1`] = `
       }
     >
       <div
-        data-css-8=""
         data-css-9=""
+        data-css-10=""
       >
         E-Mail
          
@@ -169,8 +174,8 @@ exports[`TextInput renders 1`] = `
     </div>
     <div
       className="checkmark"
-      data-css-6=""
-      data-css-8=""
+      data-css-7=""
+      data-css-9=""
     >
       <div
         dangerouslySetInnerHTML={
@@ -178,8 +183,8 @@ exports[`TextInput renders 1`] = `
             "__html": "",
           }
         }
-        data-css-8=""
-        data-css-10=""
+        data-css-9=""
+        data-css-11=""
       />
     </div>
   </div>

--- a/src/TextInput/TextInput.test.tsx.snap
+++ b/src/TextInput/TextInput.test.tsx.snap
@@ -73,8 +73,8 @@ exports[`TextInput renders 1`] = `
   padding-top: 10px !important;
 }
 
-.css-2:-ms-clear,
-[data-css-2]:-ms-clear {
+.css-2::-ms-clear,
+[data-css-2]::-ms-clear {
   display: none;
 }
 

--- a/src/Typeahead/Typeahead.test.tsx.snap
+++ b/src/Typeahead/Typeahead.test.tsx.snap
@@ -126,8 +126,8 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
   padding-top: 10px !important;
 }
 
-.css-9:-ms-clear,
-[data-css-9]:-ms-clear {
+.css-9::-ms-clear,
+[data-css-9]::-ms-clear {
   display: none;
 }
 
@@ -242,8 +242,8 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-9=""
                       data-css-4=""
+                      data-css-9=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -327,8 +327,8 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
                   aria-labelledby="downshift-19-label"
                   aria-required={false}
                   autoComplete="off"
-                  data-css-9=""
                   data-css-5=""
+                  data-css-9=""
                   id="downshift-19-input"
                   name="typed"
                   onBlur={[Function]}
@@ -526,8 +526,8 @@ exports[`Test the typeahead component should be a simple static one - in depth t
   padding-top: 10px !important;
 }
 
-.css-9:-ms-clear,
-[data-css-9]:-ms-clear {
+.css-9::-ms-clear,
+[data-css-9]::-ms-clear {
   display: none;
 }
 
@@ -642,8 +642,8 @@ exports[`Test the typeahead component should be a simple static one - in depth t
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-9=""
                       data-css-4=""
+                      data-css-9=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -727,8 +727,8 @@ exports[`Test the typeahead component should be a simple static one - in depth t
                   aria-labelledby="downshift-0-label"
                   aria-required={false}
                   autoComplete="off"
-                  data-css-9=""
                   data-css-5=""
+                  data-css-9=""
                   id="downshift-0-input"
                   name="typed"
                   onBlur={[Function]}
@@ -895,8 +895,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
   padding-top: 10px !important;
 }
 
-.css-7:-ms-clear,
-[data-css-7]:-ms-clear {
+.css-7::-ms-clear,
+[data-css-7]::-ms-clear {
   display: none;
 }
 
@@ -1130,8 +1130,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-7=""
                       data-css-3=""
+                      data-css-7=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -1882,8 +1882,8 @@ exports[`Test the typeahead component should render differently when loading 1`]
   padding-top: 10px !important;
 }
 
-.css-9:-ms-clear,
-[data-css-9]:-ms-clear {
+.css-9::-ms-clear,
+[data-css-9]::-ms-clear {
   display: none;
 }
 
@@ -1998,8 +1998,8 @@ exports[`Test the typeahead component should render differently when loading 1`]
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-9=""
                       data-css-4=""
+                      data-css-9=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -2084,8 +2084,8 @@ exports[`Test the typeahead component should render differently when loading 1`]
                   aria-labelledby="downshift-7-label"
                   aria-required={false}
                   autoComplete="off"
-                  data-css-9=""
                   data-css-5=""
+                  data-css-9=""
                   id="downshift-7-input"
                   name="typed"
                   onBlur={[Function]}
@@ -2284,8 +2284,8 @@ exports[`Test the typeahead component should render differently when loading 2`]
   padding-top: 10px !important;
 }
 
-.css-9:-ms-clear,
-[data-css-9]:-ms-clear {
+.css-9::-ms-clear,
+[data-css-9]::-ms-clear {
   display: none;
 }
 
@@ -2400,8 +2400,8 @@ exports[`Test the typeahead component should render differently when loading 2`]
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-9=""
                       data-css-4=""
+                      data-css-9=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -2486,8 +2486,8 @@ exports[`Test the typeahead component should render differently when loading 2`]
                   aria-labelledby="downshift-7-label"
                   aria-required={false}
                   autoComplete="off"
-                  data-css-9=""
                   data-css-5=""
+                  data-css-9=""
                   id="downshift-7-input"
                   name="typed"
                   onBlur={[Function]}
@@ -2812,8 +2812,8 @@ exports[`Test the typeahead component should use the defaultValue property (unco
   padding-top: 10px !important;
 }
 
-.css-16:-ms-clear,
-[data-css-16]:-ms-clear {
+.css-16::-ms-clear,
+[data-css-16]::-ms-clear {
   display: none;
 }
 
@@ -3180,8 +3180,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   padding-top: 10px !important;
 }
 
-.css-7:-ms-clear,
-[data-css-7]:-ms-clear {
+.css-7::-ms-clear,
+[data-css-7]::-ms-clear {
   display: none;
 }
 
@@ -3415,8 +3415,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-7=""
                       data-css-3=""
+                      data-css-7=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -3792,8 +3792,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   padding-top: 10px !important;
 }
 
-.css-7:-ms-clear,
-[data-css-7]:-ms-clear {
+.css-7::-ms-clear,
+[data-css-7]::-ms-clear {
   display: none;
 }
 
@@ -4028,8 +4028,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-7=""
                       data-css-3=""
+                      data-css-7=""
                       name="hint"
                       onChange={[Function]}
                       required={false}

--- a/src/Typeahead/Typeahead.test.tsx.snap
+++ b/src/Typeahead/Typeahead.test.tsx.snap
@@ -126,8 +126,13 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
   padding-top: 10px !important;
 }
 
-.css-12,
-[data-css-12] {
+.css-9:-ms-clear,
+[data-css-9]:-ms-clear {
+  display: none;
+}
+
+.css-13,
+[data-css-13] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -138,22 +143,22 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
   -moz-transition: opacity .225s;
 }
 
-.css-13,
-[data-css-13] {
+.css-14,
+[data-css-14] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-14,
-[data-css-14] {
+.css-15,
+[data-css-15] {
   position: absolute;
   top: 0;
   right: 20px;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -237,8 +242,8 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-4=""
                       data-css-9=""
+                      data-css-4=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -248,11 +253,11 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
                     />
                     <ForwardRef
                       className="checkmark"
-                      data-css-12=""
+                      data-css-13=""
                     >
                       <div
                         className="checkmark"
-                        data-css-12=""
+                        data-css-13=""
                         data-css-7=""
                       >
                         <ForwardRef
@@ -263,7 +268,7 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
                               "__html": "",
                             }
                           }
-                          data-css-13=""
+                          data-css-14=""
                         >
                           <div
                             dangerouslySetInnerHTML={
@@ -272,7 +277,7 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
                               }
                             }
                             data-css-7=""
-                            data-css-13=""
+                            data-css-14=""
                           />
                         </ForwardRef>
                       </div>
@@ -322,8 +327,8 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
                   aria-labelledby="downshift-19-label"
                   aria-required={false}
                   autoComplete="off"
-                  data-css-5=""
                   data-css-9=""
+                  data-css-5=""
                   id="downshift-19-input"
                   name="typed"
                   onBlur={[Function]}
@@ -336,11 +341,11 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
                 />
                 <ForwardRef
                   className="checkmark"
-                  data-css-12=""
+                  data-css-13=""
                 >
                   <div
                     className="checkmark"
-                    data-css-12=""
+                    data-css-13=""
                     data-css-7=""
                   >
                     <ForwardRef
@@ -351,7 +356,7 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
                           "__html": "",
                         }
                       }
-                      data-css-13=""
+                      data-css-14=""
                     >
                       <div
                         dangerouslySetInnerHTML={
@@ -360,7 +365,7 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
                           }
                         }
                         data-css-7=""
-                        data-css-13=""
+                        data-css-14=""
                       />
                     </ForwardRef>
                   </div>
@@ -370,13 +375,13 @@ exports[`Test the typeahead component Test typeahead component with jsx labels s
           </ForwardRef>
           <ForwardRef
             alignV="center"
-            data-css-14=""
+            data-css-15=""
             data-css-6=""
             direction="row"
           >
             <div
-              data-css-14=""
               data-css-15=""
+              data-css-16=""
               data-css-6=""
             />
           </ForwardRef>
@@ -521,8 +526,13 @@ exports[`Test the typeahead component should be a simple static one - in depth t
   padding-top: 10px !important;
 }
 
-.css-12,
-[data-css-12] {
+.css-9:-ms-clear,
+[data-css-9]:-ms-clear {
+  display: none;
+}
+
+.css-13,
+[data-css-13] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -533,22 +543,22 @@ exports[`Test the typeahead component should be a simple static one - in depth t
   -moz-transition: opacity .225s;
 }
 
-.css-13,
-[data-css-13] {
+.css-14,
+[data-css-14] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-14,
-[data-css-14] {
+.css-15,
+[data-css-15] {
   position: absolute;
   top: 0;
   right: 20px;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -632,8 +642,8 @@ exports[`Test the typeahead component should be a simple static one - in depth t
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-4=""
                       data-css-9=""
+                      data-css-4=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -643,11 +653,11 @@ exports[`Test the typeahead component should be a simple static one - in depth t
                     />
                     <ForwardRef
                       className="checkmark"
-                      data-css-12=""
+                      data-css-13=""
                     >
                       <div
                         className="checkmark"
-                        data-css-12=""
+                        data-css-13=""
                         data-css-7=""
                       >
                         <ForwardRef
@@ -658,7 +668,7 @@ exports[`Test the typeahead component should be a simple static one - in depth t
                               "__html": "",
                             }
                           }
-                          data-css-13=""
+                          data-css-14=""
                         >
                           <div
                             dangerouslySetInnerHTML={
@@ -667,7 +677,7 @@ exports[`Test the typeahead component should be a simple static one - in depth t
                               }
                             }
                             data-css-7=""
-                            data-css-13=""
+                            data-css-14=""
                           />
                         </ForwardRef>
                       </div>
@@ -717,8 +727,8 @@ exports[`Test the typeahead component should be a simple static one - in depth t
                   aria-labelledby="downshift-0-label"
                   aria-required={false}
                   autoComplete="off"
-                  data-css-5=""
                   data-css-9=""
+                  data-css-5=""
                   id="downshift-0-input"
                   name="typed"
                   onBlur={[Function]}
@@ -731,11 +741,11 @@ exports[`Test the typeahead component should be a simple static one - in depth t
                 />
                 <ForwardRef
                   className="checkmark"
-                  data-css-12=""
+                  data-css-13=""
                 >
                   <div
                     className="checkmark"
-                    data-css-12=""
+                    data-css-13=""
                     data-css-7=""
                   >
                     <ForwardRef
@@ -746,7 +756,7 @@ exports[`Test the typeahead component should be a simple static one - in depth t
                           "__html": "",
                         }
                       }
-                      data-css-13=""
+                      data-css-14=""
                     >
                       <div
                         dangerouslySetInnerHTML={
@@ -755,7 +765,7 @@ exports[`Test the typeahead component should be a simple static one - in depth t
                           }
                         }
                         data-css-7=""
-                        data-css-13=""
+                        data-css-14=""
                       />
                     </ForwardRef>
                   </div>
@@ -765,13 +775,13 @@ exports[`Test the typeahead component should be a simple static one - in depth t
           </ForwardRef>
           <ForwardRef
             alignV="center"
-            data-css-14=""
+            data-css-15=""
             data-css-6=""
             direction="row"
           >
             <div
-              data-css-14=""
               data-css-15=""
+              data-css-16=""
               data-css-6=""
             />
           </ForwardRef>
@@ -885,8 +895,13 @@ exports[`Test the typeahead component should be a simple static one which auto o
   padding-top: 10px !important;
 }
 
-.css-10,
-[data-css-10] {
+.css-7:-ms-clear,
+[data-css-7]:-ms-clear {
+  display: none;
+}
+
+.css-11,
+[data-css-11] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -897,22 +912,22 @@ exports[`Test the typeahead component should be a simple static one which auto o
   -moz-transition: opacity .225s;
 }
 
-.css-11,
-[data-css-11] {
+.css-12,
+[data-css-12] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-12,
-[data-css-12] {
+.css-13,
+[data-css-13] {
   position: absolute;
   top: 0;
   right: 20px;
 }
 
-.css-13,
-[data-css-13] {
+.css-14,
+[data-css-14] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -935,8 +950,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
   -webkit-flex: 0 0 auto;
 }
 
-.css-14,
-[data-css-14] {
+.css-15,
+[data-css-15] {
   align-items: stretch;
   background: transparent;
   border: none;
@@ -956,8 +971,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
   -webkit-flex-direction: column;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   background: transparent;
   border: none;
   border-bottom: 1px solid #bec3c7;
@@ -968,8 +983,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
   height: 50px;
 }
 
-.css-16,
-[data-css-16] {
+.css-17,
+[data-css-17] {
   box-shadow: 1px 1px 3px rgba(29, 29, 29, 0.125);
   max-height: 300px;
   overflow-x: hidden;
@@ -979,8 +994,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
   z-index: 9999;
 }
 
-.css-17,
-[data-css-17] {
+.css-18,
+[data-css-18] {
   box-sizing: border-box;
   align-content: stretch;
   align-items: stretch;
@@ -1003,8 +1018,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
   -webkit-flex: 0 0 auto;
 }
 
-.css-18,
-[data-css-18] {
+.css-19,
+[data-css-19] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
@@ -1012,8 +1027,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
   background-color: white;
 }
 
-.css-19,
-[data-css-19] {
+.css-20,
+[data-css-20] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -1037,8 +1052,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
   -webkit-flex: 0 0 auto;
 }
 
-.css-20,
-[data-css-20] {
+.css-21,
+[data-css-21] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -1047,8 +1062,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
   color: #333333;
 }
 
-.css-21,
-[data-css-21] {
+.css-22,
+[data-css-22] {
   position: absolute;
   right: 15px;
   bottom: 15px;
@@ -1059,7 +1074,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
   aria-haspopup="listbox"
   aria-labelledby="downshift-1-label"
   aria-owns="downshift-1-menu"
-  data-css-14=""
+  data-css-15=""
   role="combobox"
 >
   <ForwardRef
@@ -1115,8 +1130,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-3=""
                       data-css-7=""
+                      data-css-3=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -1126,11 +1141,11 @@ exports[`Test the typeahead component should be a simple static one which auto o
                     />
                     <ForwardRef
                       className="checkmark"
-                      data-css-10=""
+                      data-css-11=""
                     >
                       <div
                         className="checkmark"
-                        data-css-10=""
+                        data-css-11=""
                         data-css-5=""
                       >
                         <ForwardRef
@@ -1141,7 +1156,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
                               "__html": "",
                             }
                           }
-                          data-css-11=""
+                          data-css-12=""
                         >
                           <div
                             dangerouslySetInnerHTML={
@@ -1150,7 +1165,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
                               }
                             }
                             data-css-5=""
-                            data-css-11=""
+                            data-css-12=""
                           />
                         </ForwardRef>
                       </div>
@@ -1166,7 +1181,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             aria-controls="downshift-1-menu"
             aria-labelledby="downshift-1-label"
             autoComplete="off"
-            data-css-15=""
+            data-css-16=""
             hasRightIcon={false}
             id="downshift-1-input"
             name="typed"
@@ -1202,7 +1217,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
                   aria-required={false}
                   autoComplete="off"
                   data-css-7=""
-                  data-css-15=""
+                  data-css-16=""
                   id="downshift-1-input"
                   name="typed"
                   onBlur={[Function]}
@@ -1216,11 +1231,11 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 />
                 <ForwardRef
                   className="checkmark"
-                  data-css-10=""
+                  data-css-11=""
                 >
                   <div
                     className="checkmark"
-                    data-css-10=""
+                    data-css-11=""
                     data-css-5=""
                   >
                     <ForwardRef
@@ -1231,7 +1246,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
                           "__html": "",
                         }
                       }
-                      data-css-11=""
+                      data-css-12=""
                     >
                       <div
                         dangerouslySetInnerHTML={
@@ -1240,7 +1255,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
                           }
                         }
                         data-css-5=""
-                        data-css-11=""
+                        data-css-12=""
                       />
                     </ForwardRef>
                   </div>
@@ -1250,13 +1265,13 @@ exports[`Test the typeahead component should be a simple static one which auto o
           </ForwardRef>
           <ForwardRef
             alignV="center"
-            data-css-12=""
+            data-css-13=""
             data-css-4=""
             direction="row"
           >
             <div
-              data-css-12=""
               data-css-13=""
+              data-css-14=""
               data-css-4=""
             />
           </ForwardRef>
@@ -1273,7 +1288,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
     >
       <ForwardRef
         aria-labelledby="downshift-1-label"
-        data-css-16=""
+        data-css-17=""
         direction="column"
         id="downshift-1-menu"
         onScroll={[Function]}
@@ -1281,7 +1296,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
       >
         <ForwardRef
           aria-labelledby="downshift-1-label"
-          data-css-16=""
+          data-css-17=""
           direction="column"
           id="downshift-1-menu"
           onScroll={[Function]}
@@ -1289,8 +1304,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
         >
           <div
             aria-labelledby="downshift-1-label"
-            data-css-16=""
             data-css-17=""
+            data-css-18=""
             id="downshift-1-menu"
             onScroll={[Function]}
             role="listbox"
@@ -1298,7 +1313,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             <ForwardRef
               alignV="center"
               aria-selected={true}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-1-item-0"
               onClick={[Function]}
@@ -1313,8 +1328,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
             >
               <div
                 aria-selected={true}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-1-item-0"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -1327,10 +1342,10 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Abomasnow
@@ -1341,7 +1356,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-1-item-1"
               onClick={[Function]}
@@ -1356,8 +1371,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
             >
               <div
                 aria-selected={false}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-1-item-1"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -1370,10 +1385,10 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Abra
@@ -1384,7 +1399,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-1-item-2"
               onClick={[Function]}
@@ -1399,8 +1414,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
             >
               <div
                 aria-selected={false}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-1-item-2"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -1413,10 +1428,10 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Absol
@@ -1427,7 +1442,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-1-item-3"
               onClick={[Function]}
@@ -1442,8 +1457,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
             >
               <div
                 aria-selected={false}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-1-item-3"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -1456,10 +1471,10 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Accelgor
@@ -1470,7 +1485,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-1-item-4"
               onClick={[Function]}
@@ -1485,8 +1500,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
             >
               <div
                 aria-selected={false}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-1-item-4"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -1499,10 +1514,10 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Aegislash
@@ -1513,7 +1528,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-1-item-5"
               onClick={[Function]}
@@ -1528,8 +1543,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
             >
               <div
                 aria-selected={false}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-1-item-5"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -1542,10 +1557,10 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Aerodactyl
@@ -1556,7 +1571,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-1-item-6"
               onClick={[Function]}
@@ -1571,8 +1586,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
             >
               <div
                 aria-selected={false}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-1-item-6"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -1585,10 +1600,10 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Aggron
@@ -1599,7 +1614,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-1-item-7"
               onClick={[Function]}
@@ -1614,8 +1629,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
             >
               <div
                 aria-selected={false}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-1-item-7"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -1628,10 +1643,10 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Aipom
@@ -1642,7 +1657,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-1-item-8"
               onClick={[Function]}
@@ -1657,8 +1672,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
             >
               <div
                 aria-selected={false}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-1-item-8"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -1671,10 +1686,10 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Alakazam
@@ -1685,7 +1700,7 @@ exports[`Test the typeahead component should be a simple static one which auto o
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-1-item-9"
               onClick={[Function]}
@@ -1700,8 +1715,8 @@ exports[`Test the typeahead component should be a simple static one which auto o
             >
               <div
                 aria-selected={false}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-1-item-9"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -1714,10 +1729,10 @@ exports[`Test the typeahead component should be a simple static one which auto o
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Alomomola
@@ -1726,11 +1741,11 @@ exports[`Test the typeahead component should be a simple static one which auto o
               </div>
             </ForwardRef>
             <ForwardRef
-              data-css-21=""
+              data-css-22=""
             >
               <div
                 data-css-5=""
-                data-css-21=""
+                data-css-22=""
               />
             </ForwardRef>
           </div>
@@ -1867,8 +1882,13 @@ exports[`Test the typeahead component should render differently when loading 1`]
   padding-top: 10px !important;
 }
 
-.css-12,
-[data-css-12] {
+.css-9:-ms-clear,
+[data-css-9]:-ms-clear {
+  display: none;
+}
+
+.css-13,
+[data-css-13] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -1879,22 +1899,22 @@ exports[`Test the typeahead component should render differently when loading 1`]
   -moz-transition: opacity .225s;
 }
 
-.css-13,
-[data-css-13] {
+.css-14,
+[data-css-14] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-14,
-[data-css-14] {
+.css-15,
+[data-css-15] {
   position: absolute;
   top: 0;
   right: 20px;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -1978,8 +1998,8 @@ exports[`Test the typeahead component should render differently when loading 1`]
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-4=""
                       data-css-9=""
+                      data-css-4=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -1989,11 +2009,11 @@ exports[`Test the typeahead component should render differently when loading 1`]
                     />
                     <ForwardRef
                       className="checkmark"
-                      data-css-12=""
+                      data-css-13=""
                     >
                       <div
                         className="checkmark"
-                        data-css-12=""
+                        data-css-13=""
                         data-css-7=""
                       >
                         <ForwardRef
@@ -2004,7 +2024,7 @@ exports[`Test the typeahead component should render differently when loading 1`]
                               "__html": "",
                             }
                           }
-                          data-css-13=""
+                          data-css-14=""
                         >
                           <div
                             dangerouslySetInnerHTML={
@@ -2013,7 +2033,7 @@ exports[`Test the typeahead component should render differently when loading 1`]
                               }
                             }
                             data-css-7=""
-                            data-css-13=""
+                            data-css-14=""
                           />
                         </ForwardRef>
                       </div>
@@ -2064,8 +2084,8 @@ exports[`Test the typeahead component should render differently when loading 1`]
                   aria-labelledby="downshift-7-label"
                   aria-required={false}
                   autoComplete="off"
-                  data-css-5=""
                   data-css-9=""
+                  data-css-5=""
                   id="downshift-7-input"
                   name="typed"
                   onBlur={[Function]}
@@ -2079,11 +2099,11 @@ exports[`Test the typeahead component should render differently when loading 1`]
                 />
                 <ForwardRef
                   className="checkmark"
-                  data-css-12=""
+                  data-css-13=""
                 >
                   <div
                     className="checkmark"
-                    data-css-12=""
+                    data-css-13=""
                     data-css-7=""
                   >
                     <ForwardRef
@@ -2094,7 +2114,7 @@ exports[`Test the typeahead component should render differently when loading 1`]
                           "__html": "",
                         }
                       }
-                      data-css-13=""
+                      data-css-14=""
                     >
                       <div
                         dangerouslySetInnerHTML={
@@ -2103,7 +2123,7 @@ exports[`Test the typeahead component should render differently when loading 1`]
                           }
                         }
                         data-css-7=""
-                        data-css-13=""
+                        data-css-14=""
                       />
                     </ForwardRef>
                   </div>
@@ -2113,13 +2133,13 @@ exports[`Test the typeahead component should render differently when loading 1`]
           </ForwardRef>
           <ForwardRef
             alignV="center"
-            data-css-14=""
+            data-css-15=""
             data-css-6=""
             direction="row"
           >
             <div
-              data-css-14=""
               data-css-15=""
+              data-css-16=""
               data-css-6=""
             />
           </ForwardRef>
@@ -2264,8 +2284,13 @@ exports[`Test the typeahead component should render differently when loading 2`]
   padding-top: 10px !important;
 }
 
-.css-12,
-[data-css-12] {
+.css-9:-ms-clear,
+[data-css-9]:-ms-clear {
+  display: none;
+}
+
+.css-13,
+[data-css-13] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -2276,22 +2301,22 @@ exports[`Test the typeahead component should render differently when loading 2`]
   -moz-transition: opacity .225s;
 }
 
-.css-13,
-[data-css-13] {
+.css-14,
+[data-css-14] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-14,
-[data-css-14] {
+.css-15,
+[data-css-15] {
   position: absolute;
   top: 0;
   right: 20px;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -2375,8 +2400,8 @@ exports[`Test the typeahead component should render differently when loading 2`]
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-4=""
                       data-css-9=""
+                      data-css-4=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -2386,11 +2411,11 @@ exports[`Test the typeahead component should render differently when loading 2`]
                     />
                     <ForwardRef
                       className="checkmark"
-                      data-css-12=""
+                      data-css-13=""
                     >
                       <div
                         className="checkmark"
-                        data-css-12=""
+                        data-css-13=""
                         data-css-7=""
                       >
                         <ForwardRef
@@ -2401,7 +2426,7 @@ exports[`Test the typeahead component should render differently when loading 2`]
                               "__html": "",
                             }
                           }
-                          data-css-13=""
+                          data-css-14=""
                         >
                           <div
                             dangerouslySetInnerHTML={
@@ -2410,7 +2435,7 @@ exports[`Test the typeahead component should render differently when loading 2`]
                               }
                             }
                             data-css-7=""
-                            data-css-13=""
+                            data-css-14=""
                           />
                         </ForwardRef>
                       </div>
@@ -2461,8 +2486,8 @@ exports[`Test the typeahead component should render differently when loading 2`]
                   aria-labelledby="downshift-7-label"
                   aria-required={false}
                   autoComplete="off"
-                  data-css-5=""
                   data-css-9=""
+                  data-css-5=""
                   id="downshift-7-input"
                   name="typed"
                   onBlur={[Function]}
@@ -2476,11 +2501,11 @@ exports[`Test the typeahead component should render differently when loading 2`]
                 />
                 <ForwardRef
                   className="checkmark"
-                  data-css-12=""
+                  data-css-13=""
                 >
                   <div
                     className="checkmark"
-                    data-css-12=""
+                    data-css-13=""
                     data-css-7=""
                   >
                     <ForwardRef
@@ -2491,7 +2516,7 @@ exports[`Test the typeahead component should render differently when loading 2`]
                           "__html": "",
                         }
                       }
-                      data-css-13=""
+                      data-css-14=""
                     >
                       <div
                         dangerouslySetInnerHTML={
@@ -2500,7 +2525,7 @@ exports[`Test the typeahead component should render differently when loading 2`]
                           }
                         }
                         data-css-7=""
-                        data-css-13=""
+                        data-css-14=""
                       />
                     </ForwardRef>
                   </div>
@@ -2510,13 +2535,13 @@ exports[`Test the typeahead component should render differently when loading 2`]
           </ForwardRef>
           <ForwardRef
             alignV="center"
-            data-css-14=""
+            data-css-15=""
             data-css-6=""
             direction="row"
           >
             <div
-              data-css-14=""
               data-css-15=""
+              data-css-16=""
               data-css-6=""
             >
               <svg
@@ -2787,16 +2812,21 @@ exports[`Test the typeahead component should use the defaultValue property (unco
   padding-top: 10px !important;
 }
 
-.css-19,
-[data-css-19] {
+.css-16:-ms-clear,
+[data-css-16]:-ms-clear {
+  display: none;
+}
+
+.css-20,
+[data-css-20] {
   box-sizing: border-box;
   flex: 0 0 auto;
   cursor: pointer;
   -webkit-flex: 0 0 auto;
 }
 
-.css-20,
-[data-css-20] {
+.css-21,
+[data-css-21] {
   width: 10px;
   height: 10px;
   fill: black;
@@ -2948,8 +2978,8 @@ exports[`Test the typeahead component should use the defaultValue property (unco
                   aria-labelledby="downshift-5-label"
                   aria-required={false}
                   autoComplete="off"
-                  data-css-16=""
                   data-css-5=""
+                  data-css-16=""
                   id="downshift-5-input"
                   name="typed"
                   onBlur={[Function]}
@@ -3010,7 +3040,7 @@ exports[`Test the typeahead component should use the defaultValue property (unco
                 onClick={[Function]}
               >
                 <div
-                  data-css-19=""
+                  data-css-20=""
                   data-css-15=""
                   onClick={[Function]}
                 >
@@ -3022,7 +3052,7 @@ exports[`Test the typeahead component should use the defaultValue property (unco
                         "__html": "",
                       }
                     }
-                    data-css-20=""
+                    data-css-21=""
                     data-testid="typeahead-clear-icon"
                   >
                     <div
@@ -3032,7 +3062,7 @@ exports[`Test the typeahead component should use the defaultValue property (unco
                         }
                       }
                       data-css-7=""
-                      data-css-20=""
+                      data-css-21=""
                       data-testid="typeahead-clear-icon"
                     />
                   </ForwardRef>
@@ -3150,8 +3180,13 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   padding-top: 10px !important;
 }
 
-.css-10,
-[data-css-10] {
+.css-7:-ms-clear,
+[data-css-7]:-ms-clear {
+  display: none;
+}
+
+.css-11,
+[data-css-11] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -3162,22 +3197,22 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   -moz-transition: opacity .225s;
 }
 
-.css-11,
-[data-css-11] {
+.css-12,
+[data-css-12] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-12,
-[data-css-12] {
+.css-13,
+[data-css-13] {
   position: absolute;
   top: 0;
   right: 20px;
 }
 
-.css-13,
-[data-css-13] {
+.css-14,
+[data-css-14] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -3200,8 +3235,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-14,
-[data-css-14] {
+.css-15,
+[data-css-15] {
   align-items: stretch;
   background: transparent;
   border: none;
@@ -3221,8 +3256,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   -webkit-flex-direction: column;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   background: transparent;
   border: none;
   border-bottom: 1px solid #bec3c7;
@@ -3233,8 +3268,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   height: 50px;
 }
 
-.css-16,
-[data-css-16] {
+.css-17,
+[data-css-17] {
   box-shadow: 1px 1px 3px rgba(29, 29, 29, 0.125);
   max-height: 300px;
   overflow-x: hidden;
@@ -3244,8 +3279,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   z-index: 9999;
 }
 
-.css-17,
-[data-css-17] {
+.css-18,
+[data-css-18] {
   box-sizing: border-box;
   align-content: stretch;
   align-items: stretch;
@@ -3268,8 +3303,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-18,
-[data-css-18] {
+.css-19,
+[data-css-19] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
@@ -3277,8 +3312,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   background-color: white;
 }
 
-.css-19,
-[data-css-19] {
+.css-20,
+[data-css-20] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -3302,8 +3337,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.css-20,
-[data-css-20] {
+.css-21,
+[data-css-21] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -3312,8 +3347,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   color: #333333;
 }
 
-.css-21,
-[data-css-21] {
+.css-22,
+[data-css-22] {
   position: absolute;
   right: 15px;
   bottom: 15px;
@@ -3324,7 +3359,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
   aria-haspopup="listbox"
   aria-labelledby="downshift-2-label"
   aria-owns="downshift-2-menu"
-  data-css-14=""
+  data-css-15=""
   role="combobox"
 >
   <ForwardRef
@@ -3380,8 +3415,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-3=""
                       data-css-7=""
+                      data-css-3=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -3391,11 +3426,11 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                     />
                     <ForwardRef
                       className="checkmark"
-                      data-css-10=""
+                      data-css-11=""
                     >
                       <div
                         className="checkmark"
-                        data-css-10=""
+                        data-css-11=""
                         data-css-5=""
                       >
                         <ForwardRef
@@ -3406,7 +3441,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                               "__html": "",
                             }
                           }
-                          data-css-11=""
+                          data-css-12=""
                         >
                           <div
                             dangerouslySetInnerHTML={
@@ -3415,7 +3450,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                               }
                             }
                             data-css-5=""
-                            data-css-11=""
+                            data-css-12=""
                           />
                         </ForwardRef>
                       </div>
@@ -3431,7 +3466,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
             aria-controls="downshift-2-menu"
             aria-labelledby="downshift-2-label"
             autoComplete="off"
-            data-css-15=""
+            data-css-16=""
             hasRightIcon={false}
             id="downshift-2-input"
             name="typed"
@@ -3467,7 +3502,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                   aria-required={false}
                   autoComplete="off"
                   data-css-7=""
-                  data-css-15=""
+                  data-css-16=""
                   id="downshift-2-input"
                   name="typed"
                   onBlur={[Function]}
@@ -3481,11 +3516,11 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                 />
                 <ForwardRef
                   className="checkmark"
-                  data-css-10=""
+                  data-css-11=""
                 >
                   <div
                     className="checkmark"
-                    data-css-10=""
+                    data-css-11=""
                     data-css-5=""
                   >
                     <ForwardRef
@@ -3496,7 +3531,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                           "__html": "",
                         }
                       }
-                      data-css-11=""
+                      data-css-12=""
                     >
                       <div
                         dangerouslySetInnerHTML={
@@ -3505,7 +3540,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                           }
                         }
                         data-css-5=""
-                        data-css-11=""
+                        data-css-12=""
                       />
                     </ForwardRef>
                   </div>
@@ -3515,13 +3550,13 @@ exports[`Test the typeahead component should use the limit property 1`] = `
           </ForwardRef>
           <ForwardRef
             alignV="center"
-            data-css-12=""
+            data-css-13=""
             data-css-4=""
             direction="row"
           >
             <div
-              data-css-12=""
               data-css-13=""
+              data-css-14=""
               data-css-4=""
             />
           </ForwardRef>
@@ -3538,7 +3573,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
     >
       <ForwardRef
         aria-labelledby="downshift-2-label"
-        data-css-16=""
+        data-css-17=""
         direction="column"
         id="downshift-2-menu"
         onScroll={[Function]}
@@ -3546,7 +3581,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
       >
         <ForwardRef
           aria-labelledby="downshift-2-label"
-          data-css-16=""
+          data-css-17=""
           direction="column"
           id="downshift-2-menu"
           onScroll={[Function]}
@@ -3554,8 +3589,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
         >
           <div
             aria-labelledby="downshift-2-label"
-            data-css-16=""
             data-css-17=""
+            data-css-18=""
             id="downshift-2-menu"
             onScroll={[Function]}
             role="listbox"
@@ -3563,7 +3598,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
             <ForwardRef
               alignV="center"
               aria-selected={true}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-2-item-0"
               onClick={[Function]}
@@ -3578,8 +3613,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
             >
               <div
                 aria-selected={true}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-2-item-0"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -3592,10 +3627,10 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Abomasnow
@@ -3606,7 +3641,7 @@ exports[`Test the typeahead component should use the limit property 1`] = `
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-18=""
+              data-css-19=""
               direction="row"
               id="downshift-2-item-1"
               onClick={[Function]}
@@ -3621,8 +3656,8 @@ exports[`Test the typeahead component should use the limit property 1`] = `
             >
               <div
                 aria-selected={false}
-                data-css-18=""
                 data-css-19=""
+                data-css-20=""
                 id="downshift-2-item-1"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -3635,10 +3670,10 @@ exports[`Test the typeahead component should use the limit property 1`] = `
                 }
               >
                 <ForwardRef
-                  data-css-20=""
+                  data-css-21=""
                 >
                   <div
-                    data-css-20=""
+                    data-css-21=""
                     data-css-5=""
                   >
                     Abra
@@ -3647,11 +3682,11 @@ exports[`Test the typeahead component should use the limit property 1`] = `
               </div>
             </ForwardRef>
             <ForwardRef
-              data-css-21=""
+              data-css-22=""
             >
               <div
                 data-css-5=""
-                data-css-21=""
+                data-css-22=""
               />
             </ForwardRef>
           </div>
@@ -3757,8 +3792,13 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   padding-top: 10px !important;
 }
 
-.css-10,
-[data-css-10] {
+.css-7:-ms-clear,
+[data-css-7]:-ms-clear {
+  display: none;
+}
+
+.css-11,
+[data-css-11] {
   position: absolute;
   top: 16px;
   right: 15px;
@@ -3769,22 +3809,22 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   -moz-transition: opacity .225s;
 }
 
-.css-11,
-[data-css-11] {
+.css-12,
+[data-css-12] {
   width: 16px;
   height: 16px;
   fill: lightGrey;
 }
 
-.css-12,
-[data-css-12] {
+.css-13,
+[data-css-13] {
   position: absolute;
   top: 0;
   right: 20px;
 }
 
-.css-13,
-[data-css-13] {
+.css-14,
+[data-css-14] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -3807,8 +3847,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   -webkit-flex: 0 0 auto;
 }
 
-.css-14,
-[data-css-14] {
+.css-15,
+[data-css-15] {
   align-items: stretch;
   background: transparent;
   border: none;
@@ -3828,8 +3868,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   -webkit-flex-direction: column;
 }
 
-.css-15,
-[data-css-15] {
+.css-16,
+[data-css-16] {
   background: transparent;
   border: none;
   border-bottom: 1px solid #bec3c7;
@@ -3840,8 +3880,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   height: 50px;
 }
 
-.css-16,
-[data-css-16] {
+.css-17,
+[data-css-17] {
   padding: 10px 15px;
   min-height: 50px;
   border-bottom: 1px solid #ecf0f1;
@@ -3849,8 +3889,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   background-color: white;
 }
 
-.css-17,
-[data-css-17] {
+.css-18,
+[data-css-18] {
   box-sizing: border-box;
   align-content: center;
   align-items: center;
@@ -3874,8 +3914,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   -webkit-flex: 0 0 auto;
 }
 
-.css-18,
-[data-css-18] {
+.css-19,
+[data-css-19] {
   display: block;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -3884,8 +3924,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   color: #333333;
 }
 
-.css-19,
-[data-css-19] {
+.css-20,
+[data-css-20] {
   box-shadow: 1px 1px 3px rgba(29, 29, 29, 0.125);
   max-height: 300px;
   overflow-x: hidden;
@@ -3896,8 +3936,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   z-index: 9999;
 }
 
-.css-20,
-[data-css-20] {
+.css-21,
+[data-css-21] {
   box-sizing: border-box;
   align-content: stretch;
   align-items: stretch;
@@ -3920,8 +3960,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   -webkit-flex: 0 0 auto;
 }
 
-.css-21,
-[data-css-21] {
+.css-22,
+[data-css-22] {
   position: absolute;
   top: 15px;
   right: 15px;
@@ -3932,7 +3972,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
   aria-haspopup="listbox"
   aria-labelledby="downshift-3-label"
   aria-owns="downshift-3-menu"
-  data-css-14=""
+  data-css-15=""
   role="combobox"
 >
   <ForwardRef
@@ -3988,8 +4028,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                     <input
                       aria-required={false}
                       autoComplete="off"
-                      data-css-3=""
                       data-css-7=""
+                      data-css-3=""
                       name="hint"
                       onChange={[Function]}
                       required={false}
@@ -3999,11 +4039,11 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                     />
                     <ForwardRef
                       className="checkmark"
-                      data-css-10=""
+                      data-css-11=""
                     >
                       <div
                         className="checkmark"
-                        data-css-10=""
+                        data-css-11=""
                         data-css-5=""
                       >
                         <ForwardRef
@@ -4014,7 +4054,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                               "__html": "",
                             }
                           }
-                          data-css-11=""
+                          data-css-12=""
                         >
                           <div
                             dangerouslySetInnerHTML={
@@ -4023,7 +4063,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                               }
                             }
                             data-css-5=""
-                            data-css-11=""
+                            data-css-12=""
                           />
                         </ForwardRef>
                       </div>
@@ -4039,7 +4079,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             aria-controls="downshift-3-menu"
             aria-labelledby="downshift-3-label"
             autoComplete="off"
-            data-css-15=""
+            data-css-16=""
             hasRightIcon={false}
             id="downshift-3-input"
             name="typed"
@@ -4075,7 +4115,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                   aria-required={false}
                   autoComplete="off"
                   data-css-7=""
-                  data-css-15=""
+                  data-css-16=""
                   id="downshift-3-input"
                   name="typed"
                   onBlur={[Function]}
@@ -4089,11 +4129,11 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 />
                 <ForwardRef
                   className="checkmark"
-                  data-css-10=""
+                  data-css-11=""
                 >
                   <div
                     className="checkmark"
-                    data-css-10=""
+                    data-css-11=""
                     data-css-5=""
                   >
                     <ForwardRef
@@ -4104,7 +4144,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                           "__html": "",
                         }
                       }
-                      data-css-11=""
+                      data-css-12=""
                     >
                       <div
                         dangerouslySetInnerHTML={
@@ -4113,7 +4153,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                           }
                         }
                         data-css-5=""
-                        data-css-11=""
+                        data-css-12=""
                       />
                     </ForwardRef>
                   </div>
@@ -4123,13 +4163,13 @@ exports[`Test the typeahead component should use the top placement property 1`] 
           </ForwardRef>
           <ForwardRef
             alignV="center"
-            data-css-12=""
+            data-css-13=""
             data-css-4=""
             direction="row"
           >
             <div
-              data-css-12=""
               data-css-13=""
+              data-css-14=""
               data-css-4=""
             />
           </ForwardRef>
@@ -4146,7 +4186,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
     >
       <ForwardRef
         aria-labelledby="downshift-3-label"
-        data-css-19=""
+        data-css-20=""
         direction="column-reverse"
         id="downshift-3-menu"
         onScroll={[Function]}
@@ -4154,7 +4194,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
       >
         <ForwardRef
           aria-labelledby="downshift-3-label"
-          data-css-19=""
+          data-css-20=""
           direction="column-reverse"
           id="downshift-3-menu"
           onScroll={[Function]}
@@ -4162,8 +4202,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
         >
           <div
             aria-labelledby="downshift-3-label"
-            data-css-19=""
             data-css-20=""
+            data-css-21=""
             id="downshift-3-menu"
             onScroll={[Function]}
             role="listbox"
@@ -4171,7 +4211,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             <ForwardRef
               alignV="center"
               aria-selected={true}
-              data-css-16=""
+              data-css-17=""
               direction="row"
               id="downshift-3-item-0"
               onClick={[Function]}
@@ -4186,8 +4226,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             >
               <div
                 aria-selected={true}
-                data-css-16=""
                 data-css-17=""
+                data-css-18=""
                 id="downshift-3-item-0"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -4200,10 +4240,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 }
               >
                 <ForwardRef
-                  data-css-18=""
+                  data-css-19=""
                 >
                   <div
-                    data-css-18=""
+                    data-css-19=""
                     data-css-5=""
                   >
                     Abomasnow
@@ -4214,7 +4254,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-16=""
+              data-css-17=""
               direction="row"
               id="downshift-3-item-1"
               onClick={[Function]}
@@ -4229,8 +4269,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             >
               <div
                 aria-selected={false}
-                data-css-16=""
                 data-css-17=""
+                data-css-18=""
                 id="downshift-3-item-1"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -4243,10 +4283,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 }
               >
                 <ForwardRef
-                  data-css-18=""
+                  data-css-19=""
                 >
                   <div
-                    data-css-18=""
+                    data-css-19=""
                     data-css-5=""
                   >
                     Abra
@@ -4257,7 +4297,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-16=""
+              data-css-17=""
               direction="row"
               id="downshift-3-item-2"
               onClick={[Function]}
@@ -4272,8 +4312,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             >
               <div
                 aria-selected={false}
-                data-css-16=""
                 data-css-17=""
+                data-css-18=""
                 id="downshift-3-item-2"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -4286,10 +4326,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 }
               >
                 <ForwardRef
-                  data-css-18=""
+                  data-css-19=""
                 >
                   <div
-                    data-css-18=""
+                    data-css-19=""
                     data-css-5=""
                   >
                     Absol
@@ -4300,7 +4340,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-16=""
+              data-css-17=""
               direction="row"
               id="downshift-3-item-3"
               onClick={[Function]}
@@ -4315,8 +4355,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             >
               <div
                 aria-selected={false}
-                data-css-16=""
                 data-css-17=""
+                data-css-18=""
                 id="downshift-3-item-3"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -4329,10 +4369,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 }
               >
                 <ForwardRef
-                  data-css-18=""
+                  data-css-19=""
                 >
                   <div
-                    data-css-18=""
+                    data-css-19=""
                     data-css-5=""
                   >
                     Accelgor
@@ -4343,7 +4383,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-16=""
+              data-css-17=""
               direction="row"
               id="downshift-3-item-4"
               onClick={[Function]}
@@ -4358,8 +4398,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             >
               <div
                 aria-selected={false}
-                data-css-16=""
                 data-css-17=""
+                data-css-18=""
                 id="downshift-3-item-4"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -4372,10 +4412,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 }
               >
                 <ForwardRef
-                  data-css-18=""
+                  data-css-19=""
                 >
                   <div
-                    data-css-18=""
+                    data-css-19=""
                     data-css-5=""
                   >
                     Aegislash
@@ -4386,7 +4426,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-16=""
+              data-css-17=""
               direction="row"
               id="downshift-3-item-5"
               onClick={[Function]}
@@ -4401,8 +4441,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             >
               <div
                 aria-selected={false}
-                data-css-16=""
                 data-css-17=""
+                data-css-18=""
                 id="downshift-3-item-5"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -4415,10 +4455,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 }
               >
                 <ForwardRef
-                  data-css-18=""
+                  data-css-19=""
                 >
                   <div
-                    data-css-18=""
+                    data-css-19=""
                     data-css-5=""
                   >
                     Aerodactyl
@@ -4429,7 +4469,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-16=""
+              data-css-17=""
               direction="row"
               id="downshift-3-item-6"
               onClick={[Function]}
@@ -4444,8 +4484,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             >
               <div
                 aria-selected={false}
-                data-css-16=""
                 data-css-17=""
+                data-css-18=""
                 id="downshift-3-item-6"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -4458,10 +4498,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 }
               >
                 <ForwardRef
-                  data-css-18=""
+                  data-css-19=""
                 >
                   <div
-                    data-css-18=""
+                    data-css-19=""
                     data-css-5=""
                   >
                     Aggron
@@ -4472,7 +4512,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-16=""
+              data-css-17=""
               direction="row"
               id="downshift-3-item-7"
               onClick={[Function]}
@@ -4487,8 +4527,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             >
               <div
                 aria-selected={false}
-                data-css-16=""
                 data-css-17=""
+                data-css-18=""
                 id="downshift-3-item-7"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -4501,10 +4541,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 }
               >
                 <ForwardRef
-                  data-css-18=""
+                  data-css-19=""
                 >
                   <div
-                    data-css-18=""
+                    data-css-19=""
                     data-css-5=""
                   >
                     Aipom
@@ -4515,7 +4555,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-16=""
+              data-css-17=""
               direction="row"
               id="downshift-3-item-8"
               onClick={[Function]}
@@ -4530,8 +4570,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             >
               <div
                 aria-selected={false}
-                data-css-16=""
                 data-css-17=""
+                data-css-18=""
                 id="downshift-3-item-8"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -4544,10 +4584,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 }
               >
                 <ForwardRef
-                  data-css-18=""
+                  data-css-19=""
                 >
                   <div
-                    data-css-18=""
+                    data-css-19=""
                     data-css-5=""
                   >
                     Alakazam
@@ -4558,7 +4598,7 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             <ForwardRef
               alignV="center"
               aria-selected={false}
-              data-css-16=""
+              data-css-17=""
               direction="row"
               id="downshift-3-item-9"
               onClick={[Function]}
@@ -4573,8 +4613,8 @@ exports[`Test the typeahead component should use the top placement property 1`] 
             >
               <div
                 aria-selected={false}
-                data-css-16=""
                 data-css-17=""
+                data-css-18=""
                 id="downshift-3-item-9"
                 onClick={[Function]}
                 onMouseDown={[Function]}
@@ -4587,10 +4627,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
                 }
               >
                 <ForwardRef
-                  data-css-18=""
+                  data-css-19=""
                 >
                   <div
-                    data-css-18=""
+                    data-css-19=""
                     data-css-5=""
                   >
                     Alomomola
@@ -4599,10 +4639,10 @@ exports[`Test the typeahead component should use the top placement property 1`] 
               </div>
             </ForwardRef>
             <ForwardRef
-              data-css-21=""
+              data-css-22=""
             >
               <div
-                data-css-21=""
+                data-css-22=""
                 data-css-5=""
               />
             </ForwardRef>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,9 +24,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "awesomeTypescriptLoaderOptions": {
-    "target": "es5"
-  },
   "exclude": [
     "public",
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,9 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
+  "awesomeTypescriptLoaderOptions": {
+    "target": "es5"
+  },
   "exclude": [
     "public",
     "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4787,10 +4787,12 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.0, eslint-utils@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
-  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
+eslint-utils@>=1.4.1, eslint-utils@^1.3.0, eslint-utils@^1.3.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
+  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
There is also another rule in cockpit css about IE quirks. 
https://github.com/allthings/cockpit/blob/master/public/static/css-src/style.css#L46
https://developer.mozilla.org/en-US/docs/Web/CSS/%3A%3A-ms-reveal

It is not in the scope of this PR, but maybe that should also be added?
Checklist:

- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


