### PR TITLE
fix: label for input with set defaultValue

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "resolutions": {
     "jest/**/handlebars": ">=4.5.3",
-    "marked": ">=0.6.2"
+    "marked": ">=0.6.2",
+    "serialize-javascript": ">=2.1.1"
   },
   "peerDependencies": {
     "react": "^16.8",

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -242,18 +242,17 @@ const Input = ({
 }: IInputProps) => {
   const internalRef = useRef<HTMLTextAreaElement & HTMLInputElement>(null)
   const isTextArea = lines !== 1
-  const [changedValue, setChangedValue] = useState<
-    string | string[] | undefined
-  >(undefined)
+  const [value, setValue] = useState(
+    typeof props.value !== 'undefined' ? props.value : props.defaultValue,
+  )
 
-  const currentValue =
-    typeof changedValue !== 'undefined'
-      ? changedValue
-      : typeof props.value !== 'undefined'
-      ? props.value
-      : props.defaultValue
+  useEffect(() => {
+    if (typeof props.value !== 'undefined') {
+      setValue(props.value)
+    }
+  }, [props.value])
 
-  const length = typeof currentValue === 'string' ? currentValue.length : 0
+  const length = typeof value === 'string' ? value.length : 0
   const labelVisible = length > 0
   const showLabel = !!(label && labelVisible)
 
@@ -280,7 +279,7 @@ const Input = ({
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => {
       setValidity(e.target, customValidity)
-      setChangedValue(e.target.value)
+      setValue(e.target.value)
       props.onChange && props.onChange(e)
     },
     [customValidity, props],

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -240,15 +240,22 @@ const Input = ({
   forceHideCheckmark = false,
   ...props
 }: IInputProps) => {
-  const internalRef = useRef<any>(null)
+  const internalRef = useRef<HTMLTextAreaElement & HTMLInputElement>(null)
   const isTextArea = lines !== 1
-  const [value, setValue] = useState('')
-  const [length, setLength] = useState(
-    (typeof props.value === 'string' && props.value.length) || 0,
-  )
-  const currentValue = (props.value || value) as string
-  const labelVisible = currentValue.length > 0
-  const showLabel = !!(label && currentValue.length > 0)
+  const [changedValue, setChangedValue] = useState<
+    string | string[] | undefined
+  >(undefined)
+
+  const currentValue =
+    typeof changedValue !== 'undefined'
+      ? changedValue
+      : typeof props.value !== 'undefined'
+      ? props.value
+      : props.defaultValue
+
+  const length = typeof currentValue === 'string' ? currentValue.length : 0
+  const labelVisible = length > 0
+  const showLabel = !!(label && labelVisible)
 
   const isCheckmarkActive = forceHideCheckmark
     ? false
@@ -273,8 +280,7 @@ const Input = ({
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => {
       setValidity(e.target, customValidity)
-      setLength(e.target.value.length)
-      setValue(e.target.value)
+      setChangedValue(e.target.value)
       props.onChange && props.onChange(e)
     },
     [customValidity, props],
@@ -283,7 +289,6 @@ const Input = ({
   useEffect(() => {
     const input = internalRef.current
     if (input) {
-      setLength(input.value && input.value.length ? input.value.length : 0)
       setValidity(input, customValidity)
     }
   }, [isTextArea, customValidity])

--- a/yarn.lock
+++ b/yarn.lock
@@ -10747,10 +10747,10 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+serialize-javascript@>=2.1.1, serialize-javascript@^1.7.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serve-favicon@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
Checklist:
Fixes that the label is not displayed if an non-empty defaultValue is used on an input.

- [ ] Test added / Snapshots updated
- [ ] Documentation added / updated


